### PR TITLE
fix two links to the cypher manual

### DIFF
--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -130,7 +130,7 @@ YIELD description, tokenNames, properties, type;
 2 rows
 ----
 
-Learn more about indexes in xref:4.3@cypher-manual:ROOT:administration/indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+Learn more about indexes in xref:4.3@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/graphdb-concepts.adoc
+++ b/modules/ROOT/pages/graphdb-concepts.adoc
@@ -282,7 +282,7 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see xref:4.3@cypher-manual:ROOT:administration/indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see xref:4.3@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 [[graphdb-constraints]]
 === Constraints


### PR DESCRIPTION
Fixes a couple of links from the Getting Started Guide to the Cypher Manual where the target file has a new path.