### PR TITLE
Change xrefs from 4.4-preview to 4.4

### DIFF
--- a/modules/ROOT/pages/cypher-intro/index.adoc
+++ b/modules/ROOT/pages/cypher-intro/index.adoc
@@ -8,7 +8,7 @@ It will help you start thinking about graphs and patterns, apply this knowledge 
  
 [TIP]
 ====
-For the full reference of Cypher, see the xref:4.4-preview@cypher-manual:ROOT:index.adoc#cypher-manual[Cypher manual].
+For the full reference of Cypher, see the xref:4.4@cypher-manual:ROOT:index.adoc#cypher-manual[Cypher manual].
 ====
 
 * xref::/cypher-intro/patterns.adoc#cypher-intro-patterns[Patterns]

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -13,8 +13,8 @@ With the combination of the Cypher clauses `LOAD CSV`, `MERGE`, and `CREATE` you
 
 [NOTE]
 ====
-* For a full description of `LOAD CSV` , see xref:4.4-preview@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
-* For a full list of Cypher clauses, see xref:4.4-preview@cypher-manual:ROOT:clauses/index.adoc#query-clause[Cypher Manual -> Clauses].
+* For a full description of `LOAD CSV` , see xref:4.4@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
+* For a full list of Cypher clauses, see xref:4.4@cypher-manual:ROOT:clauses/index.adoc#query-clause[Cypher Manual -> Clauses].
 ====
 
 
@@ -193,8 +193,8 @@ It assumes that your current work directory is the _<neo4j-home>_ directory of t
 
 [NOTE]
 ====
-* For the default directory of other installations see, xref:4.4-preview@operations-manual:ROOT:configuration/file-locations/index.adoc#file-locations[Operations Manual -> File locations].
-* The import location can be configured with xref:4.4-preview@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
+* For the default directory of other installations see, xref:4.4@operations-manual:ROOT:configuration/file-locations/index.adoc#file-locations[Operations Manual -> File locations].
+* The import location can be configured with xref:4.4@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
 ====
 
 
@@ -236,7 +236,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT personIdConstraint FOR (person:Person) REQUIRE person.id IS UNIQUE
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -254,7 +254,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT movieIdConstraint FOR (movie:Movie) REQUIRE movie.id IS UNIQUE
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -278,7 +278,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE INDEX FOR (c:Country) ON (c.name)
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -301,7 +301,7 @@ LOAD CSV WITH HEADERS FROM "file:///persons.csv" AS csvLine
 CREATE (p:Person {id: toInteger(csvLine.id), name: csvLine.name})
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -317,7 +317,7 @@ Added 4 nodes, Set 8 properties, Added 4 labels
 
 [TIP]
 ====
-`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see xref:4.4-preview@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
+`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see xref:4.4@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
 ====
 
 **+2.+ Load the data from the _movies.csv_ file.**
@@ -339,7 +339,7 @@ CREATE (movie:Movie {id: toInteger(csvLine.id), title: csvLine.title, year:toInt
 CREATE (movie)-[:ORIGIN]->(country)
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -361,7 +361,7 @@ Importing the data from the _roles.csv_ file is a matter of finding the `Person`
 ====
 For larger data files, it is useful to use the hint `USING PERIODIC COMMIT` clause of `LOAD CSV`.
 This hint tells Neo4j that the query might build up inordinate amounts of transaction state, and thus needs to be periodically committed.
-For more information, see xref:4.4-preview@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[].
+For more information, see xref:4.4@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[].
 ====
 
 Using _Neo4j Browser_, run the following Cypher:
@@ -374,7 +374,7 @@ MATCH (person:Person {id: toInteger(csvLine.personId)}), (movie:Movie {id: toInt
 CREATE (person)-[:ACTED_IN {role: csvLine.role}]->(movie)
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -400,7 +400,7 @@ Using _Neo4j Browser_, run the following Cypher:
 MATCH (n)-[r]->(m) RETURN n, r, m
 ----
 
-Or using xref:4.4-preview@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----

--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -83,12 +83,12 @@ Rows: 2
 +---------------------------------------------------------------------------------------+
 ----
 
-Learn more about indexes in xref:4.4-preview@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+Learn more about indexes in xref:4.4@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in xref:4.4-preview@cypher-manual:ROOT:query-tuning/index.adoc#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in xref:4.4@cypher-manual:ROOT:query-tuning/index.adoc#query-tuning[Cypher manual -> Query tuning].
 ====
 
 
@@ -147,4 +147,4 @@ The constraint described above is available for all editions of Neo4j.
 Additional constraints are available for Neo4j Enterprise Edition.
 ====
 
-Learn more about constraints in xref:4.4-preview@cypher-manual:ROOT:constraints/index.adoc#administration-constraints[Cypher manual -> Constraints].
+Learn more about constraints in xref:4.4@cypher-manual:ROOT:constraints/index.adoc#administration-constraints[Cypher manual -> Constraints].

--- a/modules/ROOT/pages/get-started-with-neo4j.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j.adoc
@@ -23,8 +23,8 @@ All the official documentation is available at link:https://neo4j.com/docs/[].
 
 That is where you find the full manuals such as:
 
-* xref:4.4-preview@cypher-manual:ROOT:index.adoc#cypher-manual[The Cypher manual] -- This is the comprehensive manual for Cypher.
-* xref:4.4-preview@operations-manual:ROOT:index.adoc#operations-manual[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
+* xref:4.4@cypher-manual:ROOT:index.adoc#cypher-manual[The Cypher manual] -- This is the comprehensive manual for Cypher.
+* xref:4.4@operations-manual:ROOT:index.adoc#operations-manual[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
 
 The https://neo4j.com/docs/cypher-refcard/current[Cypher Refcard] is a valuable asset when learning and writing Cypher.
 

--- a/modules/ROOT/pages/graphdb-concepts.adoc
+++ b/modules/ROOT/pages/graphdb-concepts.adoc
@@ -240,7 +240,7 @@ CREATE (:Example {f: [1, 2, 3], g: [2.71, 3.14], h: ['abc', 'example'], i: [true
 
 [TIP]
 ====
-For a thorough description of the available data types, refer to the xref:4.4-preview@cypher-manual:ROOT:syntax/values/index.adoc#cypher-values[Cypher manual -> Values and types].
+For a thorough description of the available data types, refer to the xref:4.4@cypher-manual:ROOT:syntax/values/index.adoc#cypher-values[Cypher manual -> Values and types].
 ====
 
 
@@ -296,7 +296,7 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see xref:4.4-preview@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see xref:4.4@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 
 [[graphdb-constraints]]
@@ -304,7 +304,7 @@ For detailed descriptions of how to work with indexes in Cypher, see xref:4.4-pr
 
 Constraints are used to make sure that the data adheres to the rules of the domain.
 To see examples of how to work with constraints, see xref::/cypher-intro/schema.adoc#cypher-intro-constraints[Using constraints].
-For detailed descriptions of how to work with constraints in Cypher, see the xref:4.4-preview@cypher-manual:ROOT:constraints/index.adoc[Cypher manual -> Constraints].
+For detailed descriptions of how to work with constraints in Cypher, see the xref:4.4@cypher-manual:ROOT:constraints/index.adoc[Cypher manual -> Constraints].
 
 
 [[graphdb-naming-conventions]]
@@ -324,4 +324,4 @@ The following naming conventions are recommended:
 |===
 
 
-For the precise naming rules, refer to the xref:4.4-preview@cypher-manual:ROOT:syntax/naming/index.adoc#cypher-naming[Cypher manual -> Naming rules and recommendations].
+For the precise naming rules, refer to the xref:4.4@cypher-manual:ROOT:syntax/naming/index.adoc#cypher-naming[Cypher manual -> Naming rules and recommendations].


### PR DESCRIPTION
The version attribute for Neo4j manuals has been changed from `4.4-preview` to `4.4`.

This PR updates xrefs from the Getting Started Guide to other Neo4j manuals to target the 4.4 version of the relevant manual.