### PR TITLE
add conditional to exclude youtube embeds from pdf

### DIFF
--- a/modules/ROOT/pages/graph-database.adoc
+++ b/modules/ROOT/pages/graph-database.adoc
@@ -5,12 +5,13 @@ A graph database stores nodes and relationships instead of tables, or documents.
 Data is stored just like you might sketch ideas on a whiteboard.
 Your data is stored without restricting it to a pre-defined model, allowing a very flexible way of thinking about and using it.
 
+ifndef::backend-pdf[]
 ++++
 <div class="responsive-embed widescreen">
 <iframe width="640" height="360" src="https://www.youtube.com/embed/jFdEeJ-Ez1E" title="What is Neo4j?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 ++++
-
+endif::[]
 
 [[why-graphdb]]
 == Why graph databases?

--- a/modules/ROOT/pages/graphdb-vs-rdbms.adoc
+++ b/modules/ROOT/pages/graphdb-vs-rdbms.adoc
@@ -1,7 +1,6 @@
 
 [[graphdb-vs-rdbms]]
 = Concepts: Relational to Graph
-
 :description: This chapter explores the concepts of graph databases from a relational developer's point of view.
 
 .Goals
@@ -50,11 +49,13 @@ Whenever you run the equivalent of a _JOIN_ operation, the graph database uses t
 
 This ability to pre-materialize relationships into the database structure allows Neo4j to provide performance of several orders of magnitude above others, especially for join-heavy queries, allowing users to leverage a _minutes to milliseconds_ advantage.
 
+ifndef::backend-pdf[]
 ++++
 <div class="responsive-embed">
 <iframe width="640" height="360" src="https://www.youtube.com/embed/NO3C-CWykkY?start=294" frameborder="0" allowfullscreen></iframe>
 </div>
 ++++
+endif::[]
 
 [#rdbms-graph-model]
 == Data Model Differences


### PR DESCRIPTION
Adds `ifndef::backend-pdf[]` conditions to prevent the passthrough html from being included in the PDF.

Also, in _modules/ROOT/pages/graphdb-vs-rdbms.adoc_ removes a blank line before the `:description:` attribute so it is included as part of the asciidoc [document header](https://docs.asciidoctor.org/asciidoc/latest/document/header/). 