### PR TITLE
4.4-xrefs-to-links

### DIFF
--- a/modules/ROOT/pages/appendix/graphdb-concepts/index.adoc
+++ b/modules/ROOT/pages/appendix/graphdb-concepts/index.adoc
@@ -239,7 +239,7 @@ CREATE (:Example {f: [1, 2, 3], g: [2.71, 3.14], h: ['abc', 'example'], i: [true
 
 [TIP]
 ====
-For a thorough description of the available data types, refer to the xref:4.4@cypher-manual:ROOT:syntax/values/index.adoc#cypher-values[Cypher manual -> Values and types].
+For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/values#cypher-values[Cypher manual -> Values and types].
 ====
 
 
@@ -295,7 +295,7 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see xref:4.4@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 
 [[graphdb-constraints]]
@@ -303,7 +303,7 @@ For detailed descriptions of how to work with indexes in Cypher, see xref:4.4@cy
 
 Constraints are used to make sure that the data adheres to the rules of the domain.
 To see examples of how to work with constraints, see xref::/cypher-intro/schema.adoc#cypher-intro-constraints[Using constraints].
-For detailed descriptions of how to work with constraints in Cypher, see the xref:4.4@cypher-manual:ROOT:constraints/index.adoc[Cypher manual -> Constraints].
+For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints[Cypher manual -> Constraints].
 
 
 [[graphdb-naming-conventions]]
@@ -323,4 +323,4 @@ The following naming conventions are recommended:
 |===
 
 
-For the precise naming rules, refer to the xref:4.4@cypher-manual:ROOT:syntax/naming/index.adoc#cypher-naming[Cypher manual -> Naming rules and recommendations].
+For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/naming#cypher-naming[Cypher manual -> Naming rules and recommendations].

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -13,8 +13,8 @@ With the combination of the Cypher clauses `LOAD CSV`, `MERGE`, and `CREATE` you
 
 [NOTE]
 ====
-* For a full description of `LOAD CSV` , see xref:4.4@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
-* For a full list of Cypher clauses, see xref:4.4@cypher-manual:ROOT:clauses/index.adoc#query-clause[Cypher Manual -> Clauses].
+* For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv#query-load-csv[Cypher Manual -> `LOAD CSV`].
+* For a full list of Cypher clauses, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses#query-clause[Cypher Manual -> Clauses].
 ====
 
 
@@ -193,8 +193,8 @@ It assumes that your current work directory is the _<neo4j-home>_ directory of t
 
 [NOTE]
 ====
-* For the default directory of other installations see, xref:4.4@operations-manual:ROOT:configuration/file-locations/index.adoc#file-locations[Operations Manual -> File locations].
-* The import location can be configured with xref:4.4@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
+* For the default directory of other installations see, link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/file-locations#file-locations[Operations Manual -> File locations].
+* The import location can be configured with link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/configuration-settings#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
 ====
 
 
@@ -236,7 +236,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT personIdConstraint FOR (person:Person) REQUIRE person.id IS UNIQUE
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -254,7 +254,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT movieIdConstraint FOR (movie:Movie) REQUIRE movie.id IS UNIQUE
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -278,7 +278,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE INDEX FOR (c:Country) ON (c.name)
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -301,7 +301,7 @@ LOAD CSV WITH HEADERS FROM "file:///persons.csv" AS csvLine
 CREATE (p:Person {id: toInteger(csvLine.id), name: csvLine.name})
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -317,7 +317,7 @@ Added 4 nodes, Set 8 properties, Added 4 labels
 
 [TIP]
 ====
-`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see xref:4.4@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
+`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv#query-load-csv[Cypher Manual -> `LOAD CSV`].
 ====
 
 **+2.+ Load the data from the _movies.csv_ file.**
@@ -339,7 +339,7 @@ CREATE (movie:Movie {id: toInteger(csvLine.id), title: csvLine.title, year:toInt
 CREATE (movie)-[:ORIGIN]->(country)
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -361,7 +361,7 @@ Importing the data from the _roles.csv_ file is a matter of finding the `Person`
 ====
 For larger data files, it is useful to use the hint `USING PERIODIC COMMIT` clause of `LOAD CSV`.
 This hint tells Neo4j that the query might build up inordinate amounts of transaction state, and thus needs to be periodically committed.
-For more information, see xref:4.4@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning/using#query-using-periodic-commit-hint[].
 ====
 
 Using _Neo4j Browser_, run the following Cypher:
@@ -374,7 +374,7 @@ MATCH (person:Person {id: toInteger(csvLine.personId)}), (movie:Movie {id: toInt
 CREATE (person)-[:ACTED_IN {role: csvLine.role}]->(movie)
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -400,7 +400,7 @@ Using _Neo4j Browser_, run the following Cypher:
 MATCH (n)-[r]->(m) RETURN n, r, m
 ----
 
-Or using xref:4.4@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/tools/cypher-shell#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----

--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -48,7 +48,7 @@ In most cases it is not necessary to specify indexes when querying for data, as 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in xref:4.4@cypher-manual:ROOT:query-tuning/index.adoc#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning#query-tuning[Cypher manual -> Query tuning].
 ====
 
 For example, the following query will automatically use the `example_index_1`:
@@ -90,7 +90,7 @@ Rows: 2
 
 [TIP]
 ====
-Learn more about indexes in xref:4.4@cypher-manual:ROOT:indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 ====
 
 
@@ -164,5 +164,5 @@ Additional constraints are available for Neo4j Enterprise Edition.
 
 [TIP]
 ====
-Learn more about constraints in xref:4.4@cypher-manual:ROOT:constraints/index.adoc#administration-constraints[Cypher manual -> Constraints].
+Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints#administration-constraints[Cypher manual -> Constraints].
 ====

--- a/preview.yml
+++ b/preview.yml
@@ -44,3 +44,5 @@ asciidoc:
     experimental: ''
     copyright: 2022
     common-license-page-uri: https://neo4j.com/docs/license/
+    neo4j-base-uri: https://neo4j.com # this attribute should be an empty string in publish.yml
+    neo4j-docs-base-uri: https://neo4j.com/docs # this attribute should be an empty string in publish.yml

--- a/publish.yml
+++ b/publish.yml
@@ -51,3 +51,5 @@ asciidoc:
     experimental: ''
     copyright: 2021
     common-license-page-uri: https://neo4j.com/docs/license/
+    neo4j-base-uri: '' # this attribute is empty for publish playbooks
+    neo4j-docs-base-uri: ''  # this attribute is empty for publish playbooks

--- a/publish.yml
+++ b/publish.yml
@@ -52,4 +52,4 @@ asciidoc:
     copyright: 2021
     common-license-page-uri: https://neo4j.com/docs/license/
     neo4j-base-uri: '' # this attribute is empty for publish playbooks
-    neo4j-docs-base-uri: ''  # this attribute is empty for publish playbooks
+    neo4j-docs-base-uri: 'docs/'  # this attribute does not contain the full neo4j.com path for publish playbooks


### PR DESCRIPTION
Updates `xref:` macros that point to other manuals so that they use the `link:` macro instead.

This allows the getting-started content to be built and published independently.

Also adds two new attributes to playbooks. In preview.yml, as follows:

```
neo4j-base-uri: https://neo4j.com # this attribute should be an empty string in publish.yml
neo4j-docs-base-uri: https://neo4j.com/docs # this attribute should be an empty string in publish.yml
```

Using these attributes users can build locally (with `preview.yml`) and test links to live neo4j.com/docs URLs. The `neo4j-docs-base-uri` is only `docs/` in `publish.yml` because this resolves relative to neo4j.com when published.