### PR TITLE
Clean up Antora asciidoc warnings and errors

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -10,6 +10,7 @@ asciidoc:
     neo4j-version: 4.4
     neo4j-version-exact: 4.4.0
     neo4j-buildnumber: 4.4
-    offset: '{offset}'
-    count: '{count}'
-    
+    offset: '\\{offset}'
+    count: '\\{count}'
+    aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
+    neo4j-img-base-uri: https://dist.neo4j.com/wp-content/uploads/

--- a/modules/ROOT/pages/appendix/example-data.adoc
+++ b/modules/ROOT/pages/appendix/example-data.adoc
@@ -76,7 +76,7 @@ To explore a wide variety of datasets in an *online setup* without a local insta
 
 Each sandbox is available for at least three days after creation and can also be remotely accessed from applications using any Neo4j driver.
 
-// image::{img}neo4j-sandboxes.png[link=https://neo4j.com/sandbox/?ref=developer-ex-data-img]
+// image::{neo4j-img-base-uri}neo4j-sandboxes.png[link=https://neo4j.com/sandbox/?ref=developer-ex-data-img]
 
 Except for the "blank" sandbox, all other sandboxes come prepopulated with the domain data and focus on use case specific queries.
 
@@ -152,7 +152,7 @@ That's why we provided raw data (CSV, JSON, XML) for several of the datasets, ac
 
 You could run the Cypher script using a command-line client like `cypher-shell`.
 
-// image::{img}cypher-import-shell.png[]
+// image::{neo4j-img-base-uri}cypher-import-shell.png[]
 
 .Run Cypher Shell from the "Terminal" of your Graph Database in Neo4j Desktop
 [source, shell]
@@ -162,7 +162,7 @@ You could run the Cypher script using a command-line client like `cypher-shell`.
 
 You can also drag and drop or paste the script into Neo4j Browser (check that `multi-statement editor` is enabled in the settings) and run it from there.
 
-// image::{img}cypher-import-browser.png[]
+// image::{neo4j-img-base-uri}cypher-import-browser.png[]
 
 CSV data can be imported using either link:https://neo4j.com/developer/guide-import-csv/#import-load-csv[`LOAD CSV` clause in Cypher^] or https://neo4j.com/docs/operations-manual/current/tutorial/neo4j-admin-import/[`neo4j-admin import` for initial bulk imports^] of large datasets.
 
@@ -285,7 +285,7 @@ NOTE: Disclaimer: These examples are not curated and might not always represent 
 
 You can find a featured selection grouped by industry and use case at https://neo4j.com/graphgists
 
-// image::{img}neo4j-graphgists.png[link=https://neo4j.com/graphgists]
+// image::{neo4j-img-base-uri}neo4j-graphgists.png[link=https://neo4j.com/graphgists]
 
 Those examples are presented in a more long-form style that also discusses data modeling and use an temporary Neo4j store in the background.
 
@@ -293,7 +293,7 @@ To execute these examples within your Neo4j Desktop, install the *"Graph Gallery
 
 Then you can search and browse all available examples locally and run them against your *local* databases.
 
-// image::{img}graph-examples.png[link=https://install.graphapp.io]
+// image::{neo4j-img-base-uri}graph-examples.png[link=https://install.graphapp.io]
 
 If you want to submit your own graph data model example, please head to https://portal.graphgist.org to have a look at even more (non-featured) examples and create your own entries.
 

--- a/modules/ROOT/pages/appendix/getting-started-resources.adoc
+++ b/modules/ROOT/pages/appendix/getting-started-resources.adoc
@@ -4,7 +4,7 @@
 :tags: get-started, introduction, resources, neo4j-help, cypher, graph, nosql-graph, neo4j-training
 :page-pagination:
 
-[#getting-started-resources]
+
 To help you along your path of learning more about Neo4j, we want to provide you with the resources which may encourage you to dive deeper into Neo4j products and graph technology.
 
 [#graphdb-resources]
@@ -88,5 +88,5 @@ When to use which? Read more about the differences between link:https://communit
 * https://twitch.tv/neo4j/[Weekly Twitch stream sessions^]
 * http://www.opencypher.org/[openCypher project^]
 * https://neo4j.com/customers/[Neo4j Customers^]
-* xref:graph-database.adoc[Neo4j Features^]
+* xref:get-started-with-neo4j/graph-database.adoc[Neo4j Features^]
 * https://neo4j.com/licensing/[Neo4j Editions^]

--- a/modules/ROOT/pages/appendix/tutorials/guide-cypher-basics.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-cypher-basics.adoc
@@ -252,9 +252,9 @@ This is simply a shortest path query called the "Bacon Path".
 To perform this type of query, you need to specify:
 
 * Variable length patterns:
-{cyphermanual}/syntax/patterns/#cypher-pattern-varlength[variable length relationships^]
+link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/patterns/#cypher-pattern-varlength[variable length relationships^]
 * Built-in shortestPath() algorithm:
-{cyphermanual}/execution-plans/shortestpath-planning/[shortestPath^]
+link:{neo4j-docs-base-uri}/cypher-manual/current/execution-plans/shortestpath-planning/[shortestPath^]
 
 
 === Movies and actors up to three hops away from Kevin Bacon

--- a/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
@@ -3,6 +3,7 @@
 :tags: data-import, graph-import, northwind-graph, relational-graph, load-csv
 :description: This tutorial shows the process for exporting data from a relational database (PostgreSQL) and importing into a graph database (Neo4j). You will learn how to take data from the relational system and to the graph by translating the schema and using import tools.
 :page-pagination:
+:github: 'https://github.com/neo4j-contrib/developer-resources/tree/gh-pages'
 
 [abstract]
 {description}
@@ -17,7 +18,7 @@ Alternatively, you can:
 This guide uses a specific dataset, but its principles can be applied and reused with any data domain.
 
 You should have a basic understanding of the property graph model and know how to model data as a graph.
-endif::[]
+
 
 [#about-domain]
 == About the data domain
@@ -122,7 +123,7 @@ When you use `LOAD CSV` to create nodes and relationships in the database, you h
 * From a publicly-available location such as an S3 bucket or a github location. You must use this option if you are using Neo4j AuraDB or Neo4j Sandbox.
 
 If you want to use the CSV files for your Neo4j instance that you manage, you can copy the CSV files from
-link:{github}/data/northwind//northwind.zip[Northwind zip from github]
+link:{github}/data/northwind/northwind.zip[Northwind zip from github]
 and place them in the *import* folder for your Neo4j DBMS.
 
 We have already placed these CSV files in Gihub for your access to them.

--- a/modules/ROOT/pages/cypher-intro/large-statements.adoc
+++ b/modules/ROOT/pages/cypher-intro/large-statements.adoc
@@ -109,7 +109,7 @@ This allows you to execute some intermediate calculations or operations within y
 
 You must specify the variables in the `WITH` clause that you want to use later.
 Only those variables will be passed to the next part of the query.
-There are a variety of ways to use this functionality (e.g. count, collect, filter, limit results), but we will show a couple, including a cleaner version of our `size()` query from above (see xref:results.adoc#aggregate-size[Counting values in a list]).
+There are a variety of ways to use this functionality (e.g. count, collect, filter, limit results), but we will show a couple, including a cleaner version of our `size()` query from above (see xref:cypher-intro/results.adoc#aggregate-size[Counting values in a list]).
 For more information and ways to use `WITH`, check out the link:https://neo4j.com/docs/cypher-manual/current/clauses/with/[Cypher Manual section^].
 
 [source, cypher]

--- a/modules/ROOT/pages/cypher-intro/patterns-in-practice.adoc
+++ b/modules/ROOT/pages/cypher-intro/patterns-in-practice.adoc
@@ -235,10 +235,10 @@ RETURN tom.name AS name, tom.born AS `Year Born`, movie.title AS title, movie.re
 ----
 
 // .Results Without Aliases:
-// image:{img}cypher_without_aliases.jpg[role="popup-link"]
+// image:{neo4j-img-base-uri}cypher_without_aliases.jpg[role="popup-link"]
 
 // .Results With Aliases:
-// image:{img}cypher_with_aliases.jpg[role="popup-link"]
+// image:{neo4j-img-base-uri}cypher_with_aliases.jpg[role="popup-link"]
 
 [NOTE]
 --

--- a/modules/ROOT/pages/cypher-intro/procedures-functions.adoc
+++ b/modules/ROOT/pages/cypher-intro/procedures-functions.adoc
@@ -1,4 +1,3 @@
-[[procedures-functions]]
 = User defined procedures and functions
 :tags: cypher, queries, extend-cypher, procedures, functions, custom-development
 :description: This guide explains how to use, create and deploy user defined procedures and functions, the extension mechanism of Cypher, Neo4j's query language. It also covers existing, widely used procedure libraries

--- a/modules/ROOT/pages/cypher-intro/results.adoc
+++ b/modules/ROOT/pages/cypher-intro/results.adoc
@@ -570,7 +570,7 @@ image:cypher_agg_count_results.jpg[role="popup-link"]
 // RETURN p.name, collect(friend.name) AS friend
 // ----
 
-// image::{img}cypher_agg_collect.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}cypher_agg_collect.jpg[role="popup-link"]
 
 [[cypher-intro-results-collecting-aggregation]]
 == Collecting aggregation

--- a/modules/ROOT/pages/cypher-intro/updating.adoc
+++ b/modules/ROOT/pages/cypher-intro/updating.adoc
@@ -27,7 +27,7 @@ You will probably recognize some of the similarities and differences as we go al
 // Let us look at an example that we used in our last guide.
 // To review, we had a `Person` node (Jennifer) who liked graphs, was friends with Michael, and worked at Neo4j.
 
-// image::{img}cypher_graph_v1.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}cypher_graph_v1.jpg[role="popup-link"]
 
 // What if we wanted to add another of Jennifer's friends to the graph?
 // We can add Jennifer's friend Mark using the Cypher statement below.
@@ -45,7 +45,7 @@ If you do not want to return any results, simply run this statement instead:
 `CREATE (friend:Person {name: 'Mark'})`
 ////
 
-// image::{img}cypher_graph_createFriend.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}cypher_graph_createFriend.jpg[role="popup-link"]
 
 // Great! Now we added Mark to the database.
 // However, Mark is all alone with no relationships because we just created his node and did not specify any connections.
@@ -59,7 +59,7 @@ MATCH (mark:Person {name: 'Mark'})
 CREATE (jennifer)-[rel:IS_FRIENDS_WITH]->(mark)
 ////
 
-// image::{img}cypher_graph_createFriendRel.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}cypher_graph_createFriendRel.jpg[role="popup-link"]
 
 // Notice that we run two `MATCH` queries before we create a relationship between the nodes.
 // Why is that?

--- a/modules/ROOT/pages/data-import/csv-import.adoc
+++ b/modules/ROOT/pages/data-import/csv-import.adoc
@@ -286,9 +286,9 @@ To help handle larger volumes of transactions, you can increase some configurati
 * `dbms.memory.pagecache.size`: ideally, value large enough to keep the whole database in memory.
 
 ==== *LOAD CSV* resources
-* xref:appendix/guide-import-desktop-csv.adoc[How-To: Import CSV data with Neo4j Desktop]
+* xref:appendix/tutorials/guide-import-desktop-csv.adoc[How-To: Import CSV data with Neo4j Desktop]
 * link:https://neo4j.com/docs/cypher-manual/current/clauses/load-csv/[Cypher Manual: LOAD CSV^]
-* xref:appendix/guide-import-relational-and-etl.adoc[Tutorial: Import relational data into Neo4j]
+* xref:appendix/tutorials/guide-import-relational-and-etl.adoc[Tutorial: Import relational data into Neo4j]
 * link:https://graphacademy.neo4j.com/courses/importing-data[Importing CSV Data into Neo4j]
 
 [#batch-importer]
@@ -396,7 +396,7 @@ There is specific markup on specific columns, which we will explain.
 * All other columns are treated as properties but skipped if empty or annotated with `:IGNORE`.
 * Type conversion is possible by suffixing the name with indicators like `:INT`, `:BOOLEAN`, etc.
 
-For more details on this header format and the tool, see the documentation in the {opsmanual}/tools/neo4j-admin-import/[Neo4j Manual^] and the accompanying {opsmanual}/tutorial/neo4j-admin-import/[tutorial^].
+For more details on this header format and the tool, see the documentation in the link:{neo4j-docs-base-uri}/operations-manual/tools/neo4j-admin-import/[Neo4j Operations Manual^] and the accompanying link:{neo4j-docs-base-uri}/operations-manual/tutorial/neo4j-admin-import/[tutorial^].
 
 There is also a lesson in the link:https://neo4j.com/graphacademy/training-importing-data-40/enrollment/[mporting Data with Neo4j 4.x: Using neo4j-admin] that covers using the neo4j-admin import tool.
 
@@ -469,10 +469,10 @@ LIMIT 5;
 [#import-csv-resources]
 == CSV import resources
 
-* {opsmanual}/tools/neo4j-admin-import/[Manual: Import Tool^]
-* {opsmanual}/tutorial/neo4j-admin-import/#tutorial-neo4j-admin-import[Manual: Import Tool Tutorial^]
+* link:{neo4j-docs-base-uri}/operations-manual/current/tools/neo4j-admin-import/[Manual: Import Tool^]
+* link:{neo4j-docs-base-uri}/operations-manual/current/tutorial/neo4j-admin-import/#tutorial-neo4j-admin-import[Manual: Import Tool Tutorial^]
 * link:/developer/kb/?tag=load-csv[Knowledgebase Articles: LOAD CSV^]
 * link:https://github.com/neo4j-contrib/northwind-neo4j[GitHub project: Northwind CSV files^]
-* {opsmanual}/configuration/file-locations[Manual: Neo4j File Locations^]
+* link:{neo4j-docs-base-uri}/operations-manual/current/configuration/file-locations[Manual: Neo4j File Locations^]
 * link:/developer/kb/import-csv-locations/[Knowledgebase: Default Import Folder Path^].
 ////

--- a/modules/ROOT/pages/data-import/index.adoc
+++ b/modules/ROOT/pages/data-import/index.adoc
@@ -66,7 +66,7 @@ xref:data-import/relational-to-graph-import.adoc[Import: RDBMS to graph]
 In the Appendix, you can find two tutorials on how to import data from the relational database and how to import CSV data with Neo4j Desktop. +
 The first guide uses a common relational data set (Northwind) and walks you through how to transform and import data from a relational database to Neo4j graph database. You will learn what steps are needed to retrieve the data from the relational data store and import the same data as a graph in Neo4j, as well as how to take the relational data model and convert it to graph in the process.
 
-* xref:appendix/guide-import-relational-and-etl.adoc[Tutorial: Import data from a relational database into Neo4j]
-* xref:appendix/guide-import-desktop-csv.adoc[How-To: Import CSV data with Neo4j Desktop]
+* xref:appendix/tutorials/guide-import-relational-and-etl.adoc[Tutorial: Import data from a relational database into Neo4j]
+* xref:appendix/tutorials/guide-import-desktop-csv.adoc[How-To: Import CSV data with Neo4j Desktop]
 
 

--- a/modules/ROOT/pages/data-import/relational-to-graph-import.adoc
+++ b/modules/ROOT/pages/data-import/relational-to-graph-import.adoc
@@ -26,25 +26,25 @@ We will briefly cover how each operates on this page, but more detailed walkthro
 *1)* xref:data-import/csv-import.adoc[LOAD CSV]: possibly the simplest way to import data from your relational database.
 Requires a dump of individual entity-tables and join-tables formatted as CSV files.
 
-*2)* https://neo4j.com/labs/apoc/4.4/[APOC^]: Awesome Procedures on Cypher.
+*2)* link:https://neo4j.com/labs/apoc/4.4/[APOC^]: Awesome Procedures on Cypher.
 Created as an extension library to provide common procedures and functions to developers.
 This library is especially helpful for complex transformations and data manipulations.
 Useful procedures include apoc.load.jdbc, apoc.load.json, and others.
 
-*3)* https://neo4j.com/labs/etl-tool/[ETL Tool^]: Neo4j Labs UI tool that translates relational to graph from a JDBC connection.
+*3)* link:https://neo4j.com/labs/etl-tool/[ETL Tool^]: Neo4j Labs UI tool that translates relational to graph from a JDBC connection.
 Allows bulk data import for large data sets with a fast performance and simple user experience.
 
-*4)* https://medium.com/neo4j/getting-started-with-kettle-and-neo4j-32ff15b991f9[Kettle^]: open-source tool for enterprise-scale data export and import.
+*4)* link:https://medium.com/neo4j/getting-started-with-kettle-and-neo4j-32ff15b991f9[Kettle^]: open-source tool for enterprise-scale data export and import.
 Handles a variety of data sources and large data sets easily and organizes the data flow process.
 
 *5)* Other ETL tools: there are also a few vendor and community tools available for similar etl processes and GUI interaction for getting data in various formats into and out of Neo4j.
 Some of these tools also can map out the flow and transformation of data through the system.
 
-*6)* xref:language-guides/language-guides.adoc[Programmatic via drivers]: ability to retrieve data from a relational database (or other tabular structure) and use the bolt protocol to write it to Neo4j through one of the drivers with your programming language of choice.
+*6)* xref:languages-guides/index.adoc[Programmatic via drivers]: ability to retrieve data from a relational database (or other tabular structure) and use the bolt protocol to write it to Neo4j through one of the drivers with your programming language of choice.
 
 [NOTE]
 --
-You should create and understand your xref:data-modeling/data-modeling.adoc[graph data model] before transferring the data from an existing relational structure to a graph.
+You should create and understand your xref:data-modeling/index.adoc[graph data model] before transferring the data from an existing relational structure to a graph.
 If you do not have a good data model, then jumping into the import can cause frustration on data cleanup later.
 --
 

--- a/modules/ROOT/pages/data-modeling/index.adoc
+++ b/modules/ROOT/pages/data-modeling/index.adoc
@@ -22,8 +22,8 @@ To start, _Graph Modeling Guidelines_ introduces the basic process of designing 
 
 It helps you determine the questions you need to ask and share design considerations, best practices learned from experts through the years, and tips for building a more flexible and clean data model to structure your data model for the best results.
 
-xref:guide-data-modeling.adoc[Graph modeling guidelines] +
-xref:modeling-designs.adoc[Modeling designs]
+xref:data-modeling/guide-data-modeling.adoc[Graph modeling guidelines] +
+xref:data-modeling/modeling-designs.adoc[Modeling designs]
 
 [#rdbms-graph-schema]
 == Translating an RDBMS schema to graph
@@ -32,7 +32,7 @@ If you want to relate your existing knowledge of relational data models to the g
 
 From typical process steps to conversion mappings, we will walk through how the process can differ and what tables and columns look like as a graph.
 
-xref:relational-to-graph-modeling.adoc[Modeling: relational to graph]
+xref:data-modeling/relational-to-graph-modeling.adoc[Modeling: relational to graph]
 
 [#optimize-graph-model]
 == Optimizing graph data models
@@ -42,7 +42,7 @@ The data model can affect queries and performance of your use case.
 
 Learn how to improve your graph solution and maximize the capabilities of what is existing with recommendations for optimization techniques and ideas.
 
-xref:modeling-tips.adoc[Graph modeling tips]
+xref:data-modeling/modeling-tips.adoc[Graph modeling tips]
 
 [#graphgist-models]
 == Live graph models - GraphGists

--- a/modules/ROOT/pages/data-modeling/modeling-tips.adoc
+++ b/modules/ROOT/pages/data-modeling/modeling-tips.adoc
@@ -1,4 +1,3 @@
-[[modeling-tips]]
 = Graph modeling tips
 :tags: graph-modeling, data-model, schema, model-tips, model-queries
 :description: In this guide, you find some helpful information to designing a data model for your domain.  Optimizing the model helps developers to maximize performance of the system and queries.
@@ -29,7 +28,7 @@ Even if you do not know the exact query syntax just yet, understanding the inten
 == Prioritize queries
 
 It is very difficult (if not impossible) to find the perfect model for every query or functionality.
-As we talked about in the xref:modeling-designs.adoc[modeling designs guide], there are tradeoffs with choosing one particular model over another (or using multiple).
+As we talked about in the xref:data-modeling/modeling-designs.adoc[modeling designs guide], there are tradeoffs with choosing one particular model over another (or using multiple).
 While you may improve certain things, there is no way to get a one-size-fits-all solution.
 
 Instead, you should determine which model _best_ suits your needs.

--- a/modules/ROOT/pages/data-modeling/relational-to-graph-modeling.adoc
+++ b/modules/ROOT/pages/data-modeling/relational-to-graph-modeling.adoc
@@ -14,7 +14,7 @@ It will help to compare and contrast the steps of each process and help you iden
 If you are familiar with the relational data model that has tables, columns, relationship cardinalities, and other components, graph data modeling will not seem entirely foreign.
 The design of the data model still needs to be based upon requirements for access, queries, performance expectation, and business logic.
 However, the structure of a graph data model is laid out slightly differently.
-These differences were discussed in the xref:graphdb-vs-rdbms.adoc[Concepts: RDBMS to Graph] section earlier.
+These differences were discussed in the xref:appendix/graphdb-concepts/graphdb-vs-rdbms.adoc[Concepts: RDBMS to Graph] section earlier.
 
 You may have an entirely new project that you want to create a graph data model, but are only familiar with how to create the relational model.
 Or you could already have an existing project with a relational model that you want to convert to graph.
@@ -103,6 +103,6 @@ In an upcoming guide, how you model your graph data can impact queries, performa
 [#modeling-resources]
 == Resources
 * https://dzone.com/refcardz/from-relational-to-graph-a-developers-guide?chapter=1[DZone Refcard: From Relational to Graph^]
-* xref:graphdb-vs-rdbms.adoc[Concepts: Relational to Graph]
-* xref:cypher:guide-sql-to-cypher.adoc[From SQL to Cypher]
-* xref:graph-database.adoc#property-graph[Review: Property Graph Model]
+* xref:appendix/graphdb-concepts/graphdb-vs-rdbms.adoc[Concepts: Relational to Graph]
+// * xref:cypher:guide-sql-to-cypher.adoc[From SQL to Cypher]
+* xref:get-started-with-neo4j/graph-database.adoc#property-graph[Review: Property Graph Model]

--- a/modules/ROOT/pages/graph-visualization/graph-visualization-tools.adoc
+++ b/modules/ROOT/pages/graph-visualization/graph-visualization-tools.adoc
@@ -3,7 +3,7 @@
 = Graph visualization tools
 :tags: visualization, tools, neovis-js, d3-js, graphxr, yfiles, linkurious
 
-// image::{img}graph_cluster_distant_wide.jpg[]
+// image::{neo4j-img-base-uri}graph_cluster_distant_wide.jpg[]
 
 
 [#graph-vis-types]
@@ -43,7 +43,7 @@ To learn more about Neo4j Labs, visit our https://neo4j.com/labs/[Labs page^].
 To maximize functionality and data analysis capabilities through visualization, you can also combine this library with the graph algorithms library in Neo4j to style the visualization to align with results of algorithms such as page rank, centrality, communities, and more.
 Below, we see a graph visualization of Game Of Thrones character interactions rendered by neovis.js, and enhanced using Neo4j graph algorithms by applying link:/docs/graph-algorithms/current/algorithms/page-rank/[pagerank^] and link:/docs/graph-algorithms/current/algorithms/community/[community detection^] algorithms to the styling of the visualization.
 
-// image:{img}example-viz.png[role="popup-link"]
+// image:{neo4j-img-base-uri}example-viz.png[role="popup-link"]
 
 An advantage of enhancing graph visualization with these algorithms is that we can visually interpret the results of these algorithms.
 
@@ -78,7 +78,7 @@ As the first line on D3’s website states "D3.js is a JavaScript library for ma
 You can bind different kinds of data to a DOM and then execute different kinds of functions on it.
 One of those functions includes generating an SVG, canvas, or HTML visualization from the data in the DOM.
 
-// image::{img}d3_visualization.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}d3_visualization.jpg[role="popup-link",float="right",width=350]
 
 Neo4j’s movie example applications use d3.js, and you can find a variety of other projects using Neo4j and d3.
 The complicated part of D3 (or any embeddable library that doesn’t have direct Neo4j connection) is converting your graph data into the expected map format for export.
@@ -108,7 +108,7 @@ For additional information and to see everything that is available, check out th
 While some libraries are meant to include all the capabilities in one bundle, Sigma.js touts a highly-extensible environment where users can add extension libraries or plugins to provide additional capability.
 This library takes exported data in either https://github.com/jacomyal/sigma.js/tree/master/plugins/sigma.parsers.json[JSON^] or https://github.com/jacomyal/sigma.js/tree/master/plugins/sigma.parsers.gexf[GEXF^] formats.
 
-// image::{img}sigmajs_visualization.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}sigmajs_visualization.jpg[role="popup-link",float="right",width=350]
 
 Users can start from a very basic visualization right out of the box, and then begin adding custom functions and rendering for styling preferences.
 Once the requirements surpass what is possible there, users can write and use their own custom plugins for specific functionality.
@@ -150,9 +150,9 @@ They also require little or no developer integration hours and setup.
 The next paragraphs help us get a feel for the types of products in this area.
 
 === *Neo4j Bloom*
-// image:{img}neo4j_logo.png[width=200]
+// image:{neo4j-img-base-uri}neo4j_logo.png[width=200]
 
-// image::{img}bloom_screen.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}bloom_screen.jpg[role="popup-link",float="right",width=350]
 
 Neo4j Bloom is a data exploration tool that visualizes data in the graph and allows users to navigate and query the data without any query language or programming.
 
@@ -192,9 +192,9 @@ Dashboards can be saved and shared directly from your Neo4j database.
 * Try NeoDash: http://neodash.graphapp.io/[NeoDash Online Demo^]
 
 === *GraphXR*
-// image:{img}kineviz-logo.png[width=200]
+// image:{neo4j-img-base-uri}kineviz-logo.png[width=200]
 
-// image::{img}kineviz_visualization.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}kineviz_visualization.jpg[role="popup-link",float="right",width=350]
 
 GraphXR is a start-to-finish web-based visualization platform for interactive analytics.
 For technical users, it's a highly flexible and extensible environment for conducting ad hoc analysis.
@@ -216,9 +216,9 @@ The blog post about the graph app is included in the resources below.
 * Product information: https://static1.squarespace.com/static/5c58b86e8dfc8c2d0d700050/t/5c6f46559140b7665401785b/1550796373803/GraphXR%2BDatasheet.pdf[GraphXR Datasheet^]
 
 === *yFiles*
-// image:{img}yWorks.png[width=200]
+// image:{neo4j-img-base-uri}yWorks.png[width=200]
 
-// image::{img}yfiles-neo.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}yfiles-neo.jpg[role="popup-link",float="right",width=350]
 
 yWorks provides sophisticated solutions for the visualization of graphs, diagrams, and networks with yFiles, a family of high-quality, commercial software programming libraries.
 The yFiles libraries enable you to easily create sophisticated graph-based applications powered by Neo4j.
@@ -235,9 +235,9 @@ It can be installed in Neo4j Desktop.
 * Product information: https://www.yworks.com/products/yfiles[yFiles Visualization Libraries^]
 
 === *Linkurious Enterprise*
-// image:{img}Linkurious_logo_large.png[width=200]
+// image:{neo4j-img-base-uri}Linkurious_logo_large.png[width=200]
 
-// image::{img}linkurious_vis_Apr2019.png[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}linkurious_vis_Apr2019.png[role="popup-link",float="right",width=350]
 
 Linkurious Enterprise is an on-premises and browser-based platform that works on top of graph databases.
 It brings graph visualization and analysis capabilities to analysts tasked to detect and analyze threats in large volumes of connected data.
@@ -252,9 +252,9 @@ Organizations such as the French Ministry of Economy and Finance, Zurich Insuran
 * Product datasheet https://linkurio.us/wp-content/uploads/2019/04/Linkurious_Enterprise_Technical_Datasheet.pdf[Linkurious Enterprise^]
 
 === *Graphistry*
-// image:{img}graphistry-logo-rough.png[width=200]
+// image:{neo4j-img-base-uri}graphistry-logo-rough.png[width=200]
 
-// image::{img}graphistry_vis.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}graphistry_vis.jpg[role="popup-link",float="right",width=350]
 
 Graphistry brings a human interface to the age of big and complex data.
 It automatically transforms your data into interactive, visual investigation maps built for the needs of analysts.
@@ -268,9 +268,9 @@ Ideal for everything from security, fraud, and IT investigations to 3600 views o
 * Product information: https://www.graphistry.com/[Graphistry graph visualization^]
 
 === *Graphlytic*
-// image:{img}graphlytic_logo.png[width=200]
+// image:{neo4j-img-base-uri}graphlytic_logo.png[width=200]
 
-// image::{img}graphlytic_vis.png[role="popup-link",float="right",width=400]
+// image::{neo4j-img-base-uri}graphlytic_vis.png[role="popup-link",float="right",width=400]
 
 Graphlytic is a highly customizable web application for graph visualization and analysis. Users can interactively explore the graph, look for patterns with the Cypher language, or use filters to find answers to any graph question. Graph rendering is done with the Cytoscape.js library which allows Graphlytic to render tens of thousands of nodes and hundreds of thousands of relationships. 
 
@@ -284,7 +284,7 @@ The application is provided in three ways: Desktop, Cloud, and Server. Graphlyti
 * Blog post: https://graphlytic.biz/blog/parallel-relationships-models[Parallel Relationship Models with Graphlytic^]
 
 === *Perspectives*
-// image:{img}tom-sawyer-logo.png[width=200]
+// image:{neo4j-img-base-uri}tom-sawyer-logo.png[width=200]
 
 Tom Sawyer Perspectives is a robust platform for building enterprise-class graph and data visualization and analysis applications.
 It is a complete graph visualization software development kit (SDK) with a graphics-based design and preview environment.
@@ -295,7 +295,7 @@ Enterprises, system integrators, technology companies, and government agencies u
 * Product information: https://www.tomsawyer.com/perspectives/[Perspectives graph visualization^]
 
 === *Keylines*
-// image:{img}Cambridge-Intelligence-logo.jpg[width=200]
+// image:{neo4j-img-base-uri}Cambridge-Intelligence-logo.jpg[width=200]
 
 KeyLines makes it easy to build and deploy high-performance network visualization tools quickly.
 Every aspect of your application can be tailored to suit you, your data and the questions you need to answer.

--- a/modules/ROOT/pages/graph-visualization/graph-visualization.adoc
+++ b/modules/ROOT/pages/graph-visualization/graph-visualization.adoc
@@ -5,6 +5,7 @@
 :tags: visualization, graph, tools, browser, bloom, introduction, tools, charts, maps, heatmaps, 3d
 :description: This section explains graph visualization tool options, and how to get insights from your data using visualization tools.
 
+
 [abstract]
 {description}
 
@@ -17,12 +18,12 @@ Neo4j is designed to be very visual in nature.
 Native graph databases like Neo4j focus on relationships.  Visualizing these relationships can give a unique
 "big picture" to your data that is difficult or impossible to get with traditional tables and business intelligence packages.
 
-// image:{img}bloom-movies-view-1.png[role="popup-link"]
+// image:{neo4j-img-base-uri}bloom-movies-view-1.png[role="popup-link"]
 
 Graph visualization takes these capabilities one step further by drawing the graph in various formats so users can interact with the data in a more user-friendly way.
 With visualization tools, a full or partial graph can come to life and allow the user to explore it, setting various rules or views in order to analyze it from different perspectives.
 
-// image:{img}bloom-movies-view-2.png[role="popup-link"]
+// image:{neo4j-img-base-uri}bloom-movies-view-2.png[role="popup-link"]
 
 This section is designed to help you understand how to export your graph data in Neo4j for display as a visualization, and list options so you can choose what suits your needs.
 
@@ -37,13 +38,13 @@ As you can imagine, this can provide insight where other types of data formats c
 Visualizations help make anomalies or relevant patterns stand out to help human eyes and brains detect them, where other types of data formats might not highlight hidden structures as well.
 
 .Graph
-// image:{img}vis_movies_graph_format.jpg[role="popup-link"]
+// image:{neo4j-img-base-uri}vis_movies_graph_format.jpg[role="popup-link"]
 
 Let us look at a very rudimentary example of this using our Movie data from the earlier data modeling section guides.
 In the graph view above, we can easily pick out that `Lana Wachowski` directed both `Cloud Atlas` and `The Matrix` movies, where in the tabular representation, that information is not as clear or easy-to-find.
 
 .Table
-// image:{img}vis_movies_tabular_format.jpg[role="popup-link"]
+// image:{neo4j-img-base-uri}vis_movies_tabular_format.jpg[role="popup-link"]
 
 Even if you feel that the relationship is not hard to find in the tabular format, imagine if we were looking at a graph that contained these individuals' entire filmography careers, as well as hundreds of other actors, directors, and film crew members.
 The connections could easily be lost in a non-visual presentation.
@@ -59,7 +60,7 @@ We will briefly discuss the key details of each here.
 Bloom is a standalone product focused on visualization that comes with every link:{aura_signup}[AuraDB Instance], and is available with a Neo4j Desktop.  
 It was designed for business analysts annd nother non-developers to interact with graph data without writing any code.
 
-// image:{img}bloom_vis_yelp.jpg[role="popup-link"]
+// image:{neo4j-img-base-uri}bloom_vis_yelp.jpg[role="popup-link"]
 
 Users can use natural language to query the database and explore patterns, clusters, and traversals in their graph data.
 It is also possible to create different dissections of the graph (called perspectives) that allow users to view different aspects and slices of graph data for further analysis.
@@ -68,7 +69,7 @@ It is also possible to create different dissections of the graph (called perspec
 
 Neo4j Browser is an interactive cypher command shell for developers that allows you to interact with your graph and visualize the information in it. Neo4j Browser is bundled with Neo4j and is available in all editions and versions of Neo4j.
 
-// image:{img}neo4j-browser-oneshot.png[role="popup-link"]
+// image:{neo4j-img-base-uri}neo4j-browser-oneshot.png[role="popup-link"]
 
 Its visualization functionality is designed to display a node-graph representation of the underlying data stored in the database in response to a given Cypher query, showing circles for nodes and lines for relationships.
 Neo4j Browser also provides some functionality for styling with color and size based on node labels and relationship types, or you can customize your own styles by importing a GRASS (graph-stylesheet) file for Neo4j Browser to reference.
@@ -91,9 +92,9 @@ Feel free to explore others!
 
 ==== Tableau
 
-// image:{img}tableau.png[,width=200]
+// image:{neo4j-img-base-uri}tableau.png[,width=200]
 
-// image::{img}tableau-neo4j.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}tableau-neo4j.jpg[role="popup-link",float="right",width=350]
 
 Tableau is a data analysis tool that can take data from a variety of sources and blend or split the data based on user specification.
 Using the link:https://neo4j.com/bi-connector/[Neo4j Connector for BI] you can make a connection between
@@ -105,25 +106,25 @@ Once the data is in Tableau, the user can interact with a drag-and-drop Tableau 
 
 Blog post: https://medium.com/neo4j/showing-charts-for-neo4j-query-results-using-amcharts-and-structr-efae0b7a04f0[Charts for Neo4j query results with amCharts+Structr^]
 
-// image::{img}amcharts_structr.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}amcharts_structr.jpg[role="popup-link"]
 
 ==== *Chart.js*
 
 Blog post: https://neo4j.com/blog/charting-neo4j-3-0/[Charting Neo4j^]
 
-// image::{img}chart_js_visualization.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}chart_js_visualization.jpg[role="popup-link"]
 
 ==== *Nivo*
 
 Blog post: https://medium.com/neo4j/working-with-neo4j-date-and-spatial-types-in-a-react-js-app-5475b5042b50[Neo4j Spatial with Nivo charts^]
 
-// image::{img}nivo_charts_bar.jpg[role="popup-link"]
-// image::{img}nivo_charts_circle.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}nivo_charts_bar.jpg[role="popup-link"]
+// image::{neo4j-img-base-uri}nivo_charts_circle.jpg[role="popup-link"]
 
 [#graph-vis-map]
 === *Map-based visualizations*
 
-// image::{img}mapbox_visualization.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}mapbox_visualization.jpg[role="popup-link",float="right",width=350]
 
 Graph data is an excellent fit for mapping and representing geographic data, as it is laid out by entities and connections (locations/points and routes to get to those locations).
 Neo4j can help plot latitude and longitude, polygon geometries, routes, as well as distances, so a tool to overlay a map visualization on the front-end of this data provides a great deal of value for interacting and exploring an area.
@@ -148,7 +149,7 @@ Mapbox also gives you the capability to add an interactive map.
 [#graph-vis-heatmap]
 === *Heatmap visualizations*
 
-// image::{img}heatmap_visualization.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}heatmap_visualization.jpg[role="popup-link",float="right",width=350]
 
 A heatmap is a data visualization where colors are used to represent data values.
 It is often imposed on a map, but could also be on a matrix as well.
@@ -162,7 +163,7 @@ We will list the tool(s) we have encountered so far, but we will add to this as 
 [#graph-vis-3d]
 === *3D visualizations*
 
-image::{img}graph_vis_3d.jpg[role="popup-link",float="right",width=350]
+image::{neo4j-img-base-uri}graph_vis_3d.jpg[role="popup-link",float="right",width=350]
 
 Adding a third dimension may increase some complexity in the visualization, but also adds value.
 Exploring your data in 3D can help navigate through large amounts of data better and more clearly.
@@ -190,9 +191,9 @@ Instead, they expand the current boundaries and find uniquely powerful ways to u
 Thinking outside the box increases the possibilities of graph even further!
 
 .*Graphileon*
-// image:{img}graphileon-logo.png[width=200]
+// image:{neo4j-img-base-uri}graphileon-logo.png[width=200]
 
-// image::{img}graphileon_visualization.jpg[role="popup-link",float="right",width=350]
+// image::{neo4j-img-base-uri}graphileon_visualization.jpg[role="popup-link",float="right",width=350]
 
 Graphileon is a platform for building graphy applications by composing functions and UI elements.
 It can be harnessed by users such as consultants and designers for styling and dashboards.

--- a/modules/ROOT/pages/languages-guides/java/java-intro.adoc
+++ b/modules/ROOT/pages/languages-guides/java/java-intro.adoc
@@ -21,7 +21,7 @@ When developing with Neo4j, please use Java 8 or 11 and your favorite IDE.
 [#neo4j-java]
 == Neo4j for Java developers
 
-// image::{img}java.jpg[float=right,width=200]
+// image::{neo4j-img-base-uri}java.jpg[float=right,width=200]
 
 Neo4j provides drivers which allow you to make a connection to the database and develop applications
 which create, read, update, and delete information from the graph.

--- a/modules/ROOT/pages/languages-guides/java/java-third-party.adoc
+++ b/modules/ROOT/pages/languages-guides/java/java-third-party.adoc
@@ -97,7 +97,7 @@ At the bottom level of abstraction, a *native Java DSL* in the form of a fluent 
 [#neo4j-grails]
 === Groovy & Grails: Neo4j Grails Plugin
 
-// image::{img}grails.png[width=200,float=right]
+// image::{neo4j-img-base-uri}grails.png[width=200,float=right]
 
 The goal of GORM for Neo4j is to provide a 'as-complete-as-possible' GORM implementation that maps domain classes and instances to the Neo4j nodespace. The following features are supported:
 
@@ -118,7 +118,7 @@ The goal of GORM for Neo4j is to provide a 'as-complete-as-possible' GORM implem
 [#neo4j-scala]
 === Scala: neotypes
 
-// image::{img}scala.png[width=200,float="right"]
+// image::{neo4j-img-base-uri}scala.png[width=200,float="right"]
 
 Scala lightweight, type-safe, asynchronous driver (not opinionated on side-effect implementation) for neo4j.
 The project aims to provide seamless integration with most popular scala infrastructures such as lightbend (Akka, Akka-http, Lagom, etc), typelevel (cats, http4s, etc), twitter (finch, etc)...

--- a/modules/ROOT/pages/languages-guides/java/neo4j-ogm.adoc
+++ b/modules/ROOT/pages/languages-guides/java/neo4j-ogm.adoc
@@ -1,4 +1,3 @@
-[[neo4j-ogm]]
 = Neo4j - OGM Object Graph Mapper
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
 :neo4j-ogm-version: 3.2.23
@@ -22,8 +21,8 @@ While using the Cypher query language alongside the Java driver works well for s
 That's where object graph mappers come in; they take your existing domain objects (POJOs) and map them to Neo4j.
 The great benefit with this approach is that with graph databases, there is no data-model impedence mismatch like there is with relational databases.
 
-Besides the Neo4j-OGM, there is also xref:java-third-party.adoc#ogm-hibernate[Hibernate-OGM] and others.
-If you want more abstraction xref:spring-data-neo4j.adoc[Spring Data Neo4j] can give you a Domain Driver Design (DDD) approach.
+Besides the Neo4j-OGM, there is also xref:languages-guides/java/java-third-party.adoc#ogm-hibernate[Hibernate-OGM] and others.
+If you want more abstraction xref:languages-guides/java/spring-data-neo4j.adoc[Spring Data Neo4j] can give you a Domain Driver Design (DDD) approach.
 
 We created the Neo4j-OGM as a standalone, simple object graph mapper for Java which also acts as the base for Spring Data Neo4j.
 

--- a/modules/ROOT/pages/languages-guides/java/spring-data-neo4j.adoc
+++ b/modules/ROOT/pages/languages-guides/java/spring-data-neo4j.adoc
@@ -14,17 +14,17 @@
 The library provides convenient access to Neo4j including object mapping, Spring Data repositories, conversion, transaction handling, reactive support, and more.
 
 [abstract]
-* Familiarity with xref:graph-database.adoc[graph database] concepts and the xref:graph-database.adoc#property-graph[property graph model].
+* Familiarity with xref:get-started-with-neo4j/graph-database.adoc[graph database] concepts and the xref:get-started-with-neo4j/graph-database.adoc#property-graph[property graph model].
 * link:{aura_signup}[Create an AuraDB Free instance] and familiarity with the link:/developer/cypher-query-language[Cypher query language]
 * Some knowledge/experience with Spring.
-Knowing https://spring.io/projects/spring-data/[Spring Data^] and https://spring.io/projects/spring-boot/[Spring Boot^] are both great additions to your toolbox, as well.
+Knowing link:https://spring.io/projects/spring-data/[Spring Data^] and link:https://spring.io/projects/spring-boot/[Spring Boot^] are both great additions to your toolbox, as well.
 * For this library, please use JDK 11 or later and your favorite IDE.
 
 
 [#reactive-development]
 == Reactive Development
 
-Neo4j (version 4.0+) incorporated the principles of the https://www.reactivemanifesto.org/[reactive manifesto^] for passing data between the database and client with the drivers.
+Neo4j (version 4.0+) incorporated the principles of the link:https://www.reactivemanifesto.org/[reactive manifesto^] for passing data between the database and client with the drivers.
 Developers can take advantage of the reactive approach to process queries and return results.
 This means that communication between the driver, and the database can be managed and adjusted dynamically according to data needs of the client.
 
@@ -34,7 +34,7 @@ Neo4j's database driver will also maintain rate limits for requesting data from 
 No matter the volume of transactions or data (even during times of high activity), the system can maintain limits on how much it can send and receive at once based on available resources.
 This prevents overloads and collapses or failures, as well as lost transmissions or later catch up loads during the downtime.
 
-https://projectreactor.io/[Project Reactor^] is the core foundation of many implementations of reactive development, including https://spring.io/reactive[Spring's^].
+link:https://projectreactor.io/[Project Reactor^] is the core foundation of many implementations of reactive development, including link:https://spring.io/reactive[Spring's^].
 Neo4j uses the Spring implementation of Project Reactor components to provide reactive support in related applications with the graph database.
 
 [#spring-data]
@@ -42,10 +42,10 @@ Neo4j uses the Spring implementation of Project Reactor components to provide re
 
 The Spring Data Neo4j 6 is the new major version of the Spring Data Neo4j project.
 One of its feature benefit is the capability and support for reactive transactions, though there are other improvements and additions
-such as fully immutable entity and https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/lang/Record.html[Java record]-based mapping support.
+such as fully immutable entity and link:https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/lang/Record.html[Java record]-based mapping support.
 
 While SDN provides both imperative and reactive application development, this guide will focus on the reactive implementation.
-Imperative application code and documentation in SDN is available on the https://github.com/spring-projects/spring-data-neo4j[Github project^].
+Imperative application code and documentation in SDN is available on the link:https://github.com/spring-projects/spring-data-neo4j[Github project^].
 
 We can see some of the most prominent features and changes in the SDN library listed below.
 
@@ -78,7 +78,7 @@ Over the next few sections, we will walk through all of the steps for creating a
 
 For this example, we will use the Neo4j-standard movie graph data set because it comes for free with every Neo4j instance and is a small size.
 
-If you haven't already, link:/download/[download Neo4j Desktop^] and xref:neo4j-desktop.adoc#desktop-create-DBMS[create/start a database].
+If you haven't already, link:/download/[download Neo4j Desktop^] and link:{neo4j-docs-base-uri}/desktop-manual/current/operations/create-dbms/[create/start a database].
 
 You can interact with the database and load the data in a web browser with the URL http://localhost:7474/browser/?cmd=play&arg=movies[http://localhost:7474^].
 Note the command ready to run in the prompt (`:play movies`).
@@ -88,7 +88,7 @@ On the second slide of that guide, execute the long Cypher statement to fill you
 [#create-project]
 == Create a new Spring Boot project
 
-The easiest way to set up a Spring Boot project is with the Spring Initializr at https://start.spring.io[start.spring.io^].
+The easiest way to set up a Spring Boot project is with the Spring Initializr at link:https://start.spring.io[start.spring.io^].
 It is also integrated in the major IDEs, in case you prefer not to use the website.
 
 Then, you can change the default group, artifact, name, and description for the project.
@@ -103,7 +103,7 @@ The Spring Initializr will take care of creating the project structure for you, 
 If you are looking at the project in Github, you might notice that there are some other dependencies in the `pom.xml`.
 A couple are for adding tests to the project, then one dependency for developer tools, and a couple more for test containers.
 
-More information on the testing functionality can be found in the https://docs.spring.io/spring-data/neo4j/docs/current/reference/html/#sdn.testing[documentation^].
+More information on the testing functionality can be found in the link:https://docs.spring.io/spring-data/neo4j/docs/current/reference/html/#sdn.testing[documentation^].
 
 .Testing and dev tools dependencies
 [source,xml,subs="verbatim,attributes"]

--- a/modules/ROOT/pages/languages-guides/neo4j-dotnet.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-dotnet.adoc
@@ -1,4 +1,3 @@
-[[neo4j-dotnet]]
 = Using Neo4j from .NET
 :examples: https://github.com/neo4j-examples
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
@@ -19,7 +18,7 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 [#neo4j-dotnet]
 == Neo4j for .NET Developers
 
-// image::{img}dotnet-logo.png[float=right,width=300]
+// image::{neo4j-img-base-uri}dotnet-logo.png[float=right,width=300]
 
 Neo4j provides drivers which allow you to make a connection to the database and develop applications
 which create, read, update, and delete information from the graph.

--- a/modules/ROOT/pages/languages-guides/neo4j-erlang-elixir.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-erlang-elixir.adoc
@@ -28,8 +28,8 @@ Neo4j does not take any responsibility for their usability.
 [[neo4j-erlang-elixir]]
 == Neo4j for Erlang/Elixir Developers
 
-// image::{img}erlang.png[float=right,width=150]
-// image::{img}elixir.png[float=left,width=150]
+// image::{neo4j-img-base-uri}erlang.png[float=right,width=150]
+// image::{neo4j-img-base-uri}elixir.png[float=left,width=150]
 
 Members of the Erlang and Elixir community have invested a lot of time and love to develop these drivers, so if you use them, please provide feedback to the authors.
 

--- a/modules/ROOT/pages/languages-guides/neo4j-go.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-go.adoc
@@ -1,4 +1,3 @@
-[[neo4j-go]]
 = Using Neo4j from Go
 :go-driver-version: 4.4.3
 :tags: golang, go, app-development, applications
@@ -14,7 +13,7 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 [#neo4j-go]
 == Neo4j for Go Developers
 
-// image::{img}GO.jpg[width=150,float=right]
+// image::{neo4j-img-base-uri}GO.jpg[width=150,float=right]
 
 Neo4j provides drivers which allow you to make a connection to the database and develop applications
 which create, read, update, and delete information from the graph.

--- a/modules/ROOT/pages/languages-guides/neo4j-javascript.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-javascript.adoc
@@ -1,4 +1,3 @@
-[[neo4j-javascript]]
 = Neo4j from JavaScript
 :javascript-driver-version: 4.4.7
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
@@ -24,7 +23,7 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 [#neo4j-javascript]
 == Neo4j for JavaScript Developers
 
-// image::{img}nodejs.png[float=right,width=300]
+// image::{neo4j-img-base-uri}nodejs.png[float=right,width=300]
 
 Neo4j provides drivers which allow you to make a connection to the database and develop applications
 which create, read, update, and delete information from the graph.

--- a/modules/ROOT/pages/languages-guides/neo4j-perl.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-perl.adoc
@@ -1,4 +1,3 @@
-[[neo4j-perl]]
 = Perl: Neo4j Community Drivers
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
 :examples: https://github.com/neo4j-examples
@@ -19,8 +18,8 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 
 Members of the each programming language community have invested a lot of time and love to develop each one of the community drivers for Neo4j, so if you use any one of them, please provide feedback to the authors.
 
-====
 [NOTE]
+====
 icon:users[size=2x]
 The community drivers have been graciously contributed by the Neo4j community.
 Many of them are fully featured and well-maintained, but some may not be.
@@ -30,7 +29,7 @@ Neo4j does not take any responsibility for their usability.
 [#neo4j-perl]
 == Neo4j for Perl developers
 
-// image::{img}perl.png[float=right]
+// image::{neo4j-img-base-uri}perl.png[float=right]
 
 Members of the Perl community have invested a lot of time and love to develop drivers for Neo4j, so if you use them, please provide feedback to the authors.
 

--- a/modules/ROOT/pages/languages-guides/neo4j-php.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-php.adoc
@@ -1,4 +1,3 @@
-[[neo4j-php]]
 = Using Neo4j from PHP
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
 :tags: php, ogm, app-development, applications, driver, client, bolt
@@ -22,7 +21,7 @@ When developing with Neo4j, please use Java 8 or 11 and your favorite IDE.
 [#neo4j-php]
 == Neo4j for PHP Developers
 
-// image::{img}php_logo.png[float=right,width=300]
+// image::{neo4j-img-base-uri}php_logo.png[float=right,width=300]
 
 
 Alternatively, Neo4j can be installed on any system and then accessed via its bolt and HTTP APIs. We recommend the https://github.com/laudis-technologies/neo4j-php-client#roadmap[PHP Client^] for easiest development over bolt and HTTP APIs. You can also directly access the bolt protocol via the https://github.com/stefanak-michal/Bolt[PHP Bolt] library.

--- a/modules/ROOT/pages/languages-guides/neo4j-python.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-python.adoc
@@ -1,4 +1,3 @@
-[[neo4j-python]]
 = Using Neo4j from Python
 :python-driver-version: 4.4.5
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
@@ -17,7 +16,7 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 [#neo4j-python]
 == Neo4j and Python
 
-// image::{img}python-logo.png[width=300,float="right"]
+// image::{neo4j-img-base-uri}python-logo.png[width=300,float="right"]
 
 Neo4j provides drivers which allow you to make a connection to the database and develop applications
 which create, read, update, and delete information from the graph.
@@ -148,7 +147,7 @@ While we do not provide a specific web framework recommendation, both the lightw
 [#py2neo-lib]
 === Py2neo
 
-// image::{img}py2neo.200x200.png[float="right",width=100]
+// image::{neo4j-img-base-uri}py2neo.200x200.png[float="right",width=100]
 
 Py2neo is a client library and comprehensive toolkit for working with Neo4j from within Python applications and from the command line.
 It has been carefully designed to be easy and intuitive to use.
@@ -186,7 +185,7 @@ alice, bob, carol = [result.one for result in tx.commit()]
 [#neomodel-lib]
 === Neomodel
 
-image::{img}neomodel.200x80.png[float="right",width=100]
+image::{neo4j-img-base-uri}neomodel.200x80.png[float="right",width=100]
 
 An Object Graph Mapper built on top of the Neo4j python driver.
 Familiar Django style node definitions with a powerful query API, thread safe and full transaction support.

--- a/modules/ROOT/pages/languages-guides/neo4j-ruby.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-ruby.adoc
@@ -1,4 +1,3 @@
-[[neo4j-ruby]]
 = Using Neo4j from Ruby
 :aura_signup: https://neo4j.com/cloud/aura/?ref=developer-guides
 :tags: ruby, gem, app-development, applications


### PR DESCRIPTION
Fixes issues reported in the Antora log, such as bad xrefs and missing attributes.

Remaining log messages are:
- xrefs to Operations manual and Cypher manual, which are addressed by #115
- missing attribute `neo4j-docs-base-uri`. also addressed by #115
- `expected substitution value for custom inline macro` error, which will be addressed by a future PR updating the package dependency versions.