### PR TITLE
Replace external xrefs with link macros

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -10,6 +10,6 @@ asciidoc:
     neo4j-version: 4.0
     neo4j-version-exact: 4.0.12
     neo4j-buildnumber: 4.0
-    offset: '{offset}'
-    count: '{count}'
+    offset: '\\{offset}'
+    count: '\\{count}'
     

--- a/modules/ROOT/pages/cypher-intro/index.adoc
+++ b/modules/ROOT/pages/cypher-intro/index.adoc
@@ -8,7 +8,7 @@ It will help you start thinking about graphs and patterns, apply this knowledge 
  
 [TIP]
 ====
-For the full reference of Cypher, see the xref:4.0@cypher-manual:ROOT:index.adoc#cypher-manual[Cypher manual].
+For the full reference of Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/4.0/[Cypher manual].
 ====
 
 * xref::/cypher-intro/patterns.adoc#cypher-intro-patterns[Patterns]

--- a/modules/ROOT/pages/cypher-intro/index.adoc
+++ b/modules/ROOT/pages/cypher-intro/index.adoc
@@ -8,7 +8,7 @@ It will help you start thinking about graphs and patterns, apply this knowledge 
  
 [TIP]
 ====
-For the full reference of Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/4.0/[Cypher manual].
+For the full reference of Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/[Cypher manual].
 ====
 
 * xref::/cypher-intro/patterns.adoc#cypher-intro-patterns[Patterns]

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -13,8 +13,8 @@ With the combination of the Cypher clauses `LOAD CSV`, `MERGE`, and `CREATE` you
 
 [NOTE]
 ====
-* For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/4.0/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
-* For a full list of Cypher clauses, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/clauses/#query-clause[Cypher Manual -> Clauses].
+* For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
+* For a full list of Cypher clauses, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/clauses/#query-clause[Cypher Manual -> Clauses].
 ====
 
 
@@ -193,8 +193,8 @@ It assumes that your current work directory is the _<neo4j-home>_ directory of t
 
 [NOTE]
 ====
-* For the default directory of other installations see, link:{neo4j-docs-base-uri}/operations-manual/4.0/configuration/file-locations/#file-locations[Operations Manual -> File locations].
-* The import location can be configured with link:{neo4j-docs-base-uri}/operations-manual/4.0/reference/configuration-settings/#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
+* For the default directory of other installations see, link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/configuration/file-locations/#file-locations[Operations Manual -> File locations].
+* The import location can be configured with link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/reference/configuration-settings/#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
 ====
 
 
@@ -236,7 +236,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT personIdConstraint ON (person:Person) ASSERT person.id IS UNIQUE
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -254,7 +254,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT movieIdConstraint ON (movie:Movie) ASSERT movie.id IS UNIQUE
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -278,7 +278,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE INDEX FOR (c:Country) ON (c.name)
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -301,7 +301,7 @@ LOAD CSV WITH HEADERS FROM "file:///persons.csv" AS csvLine
 CREATE (p:Person {id: toInteger(csvLine.id), name: csvLine.name})
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -317,7 +317,7 @@ Added 4 nodes, Set 8 properties, Added 4 labels
 
 [TIP]
 ====
-`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
+`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
 ====
 
 **+2.+ Load the data from the _movies.csv_ file.**
@@ -339,7 +339,7 @@ CREATE (movie:Movie {id: toInteger(csvLine.id), title: csvLine.title, year:toInt
 CREATE (movie)-[:ORIGIN]->(country)
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -361,7 +361,7 @@ Importing the data from the _roles.csv_ file is a matter of finding the `Person`
 ====
 For larger data files, it is useful to use the hint `USING PERIODIC COMMIT` clause of `LOAD CSV`.
 This hint tells Neo4j that the query might build up inordinate amounts of transaction state, and thus needs to be periodically committed.
-For more information, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/query-tuning/using/#query-using-periodic-commit-hint[].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/query-tuning/using/#query-using-periodic-commit-hint[].
 ====
 
 Using _Neo4j Browser_, run the following Cypher:
@@ -374,7 +374,7 @@ MATCH (person:Person {id: toInteger(csvLine.personId)}), (movie:Movie {id: toInt
 CREATE (person)-[:ACTED_IN {role: csvLine.role}]->(movie)
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -400,7 +400,7 @@ Using _Neo4j Browser_, run the following Cypher:
 MATCH (n)-[r]->(m) RETURN n, r, m
 ----
 
-Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -13,8 +13,8 @@ With the combination of the Cypher clauses `LOAD CSV`, `MERGE`, and `CREATE` you
 
 [NOTE]
 ====
-* For a full description of `LOAD CSV` , see xref:4.0@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
-* For a full list of Cypher clauses, see xref:4.0@cypher-manual:ROOT:clauses/index.adoc#query-clause[Cypher Manual -> Clauses].
+* For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/4.0/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
+* For a full list of Cypher clauses, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/clauses/#query-clause[Cypher Manual -> Clauses].
 ====
 
 
@@ -193,8 +193,8 @@ It assumes that your current work directory is the _<neo4j-home>_ directory of t
 
 [NOTE]
 ====
-* For the default directory of other installations see, xref:4.0@operations-manual:ROOT:configuration/file-locations/index.adoc#file-locations[Operations Manual -> File locations].
-* The import location can be configured with xref:4.0@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
+* For the default directory of other installations see, link:{neo4j-docs-base-uri}/operations-manual/4.0/configuration/file-locations/#file-locations[Operations Manual -> File locations].
+* The import location can be configured with link:{neo4j-docs-base-uri}/operations-manual/4.0/reference/configuration-settings/#config_dbms.directories.import[Operations Manual -> `dbms.directories.import`].
 ====
 
 
@@ -236,7 +236,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT personIdConstraint ON (person:Person) ASSERT person.id IS UNIQUE
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -254,7 +254,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE CONSTRAINT movieIdConstraint ON (movie:Movie) ASSERT movie.id IS UNIQUE
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -278,7 +278,7 @@ Using _Neo4j Browser_, run the following Cypher:
 CREATE INDEX FOR (c:Country) ON (c.name)
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -301,7 +301,7 @@ LOAD CSV WITH HEADERS FROM "file:///persons.csv" AS csvLine
 CREATE (p:Person {id: toInteger(csvLine.id), name: csvLine.name})
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -317,7 +317,7 @@ Added 4 nodes, Set 8 properties, Added 4 labels
 
 [TIP]
 ====
-`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see xref:4.0@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
+`LOAD CSV` also supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
 ====
 
 **+2.+ Load the data from the _movies.csv_ file.**
@@ -339,7 +339,7 @@ CREATE (movie:Movie {id: toInteger(csvLine.id), title: csvLine.title, year:toInt
 CREATE (movie)-[:ORIGIN]->(country)
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -361,7 +361,7 @@ Importing the data from the _roles.csv_ file is a matter of finding the `Person`
 ====
 For larger data files, it is useful to use the hint `USING PERIODIC COMMIT` clause of `LOAD CSV`.
 This hint tells Neo4j that the query might build up inordinate amounts of transaction state, and thus needs to be periodically committed.
-For more information, see xref:4.0@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/query-tuning/using/#query-using-periodic-commit-hint[].
 ====
 
 Using _Neo4j Browser_, run the following Cypher:
@@ -374,7 +374,7 @@ MATCH (person:Person {id: toInteger(csvLine.personId)}), (movie:Movie {id: toInt
 CREATE (person)-[:ACTED_IN {role: csvLine.role}]->(movie)
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----
@@ -400,7 +400,7 @@ Using _Neo4j Browser_, run the following Cypher:
 MATCH (n)-[r]->(m) RETURN n, r, m
 ----
 
-Or using xref:4.0@operations-manual:ROOT:tools/cypher-shell/index.adoc#cypher-shell[_Neo4j Cypher Shell_], run the command:
+Or using link:{neo4j-docs-base-uri}/operations-manual/4.0/tools/cypher-shell/#cypher-shell[_Neo4j Cypher Shell_], run the command:
 
 [source, shell, indent=0]
 ----

--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -83,12 +83,12 @@ Rows: 2
 +---------------------------------------------------------------------------------------+
 ----
 
-Learn more about indexes in xref:4.0@cypher-manual:ROOT:administration/indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/indexes-for-full-text-search/#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in xref:4.0@cypher-manual:ROOT:query-tuning/index.adoc#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/4.0/query-tuning/#query-tuning[Cypher manual -> Query tuning].
 ====
 
 
@@ -136,4 +136,4 @@ The constraint described above is available for all editions of Neo4j.
 Additional constraints are available for Neo4j Enterprise Edition.
 ====
 
-Learn more about constraints in xref:4.0@cypher-manual:ROOT:administration/constraints/index.adoc#administration-constraints[Cypher manual -> Constraints].
+Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/constraints/#administration-constraints[Cypher manual -> Constraints].

--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -83,12 +83,12 @@ Rows: 2
 +---------------------------------------------------------------------------------------+
 ----
 
-Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/indexes-for-full-text-search/#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/administration/indexes-for-full-text-search/#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/4.0/query-tuning/#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/query-tuning/#query-tuning[Cypher manual -> Query tuning].
 ====
 
 
@@ -136,4 +136,4 @@ The constraint described above is available for all editions of Neo4j.
 Additional constraints are available for Neo4j Enterprise Edition.
 ====
 
-Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/constraints/#administration-constraints[Cypher manual -> Constraints].
+Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/administration/constraints/#administration-constraints[Cypher manual -> Constraints].

--- a/modules/ROOT/pages/get-started-with-neo4j.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j.adoc
@@ -23,9 +23,9 @@ All the official documentation is available at link:https://neo4j.com/docs/[].
 
 That is where you find the full manuals such as:
 
-* link:{neo4j-docs-base-uri}/cypher-manual/4.0/[The Cypher manual] -- This is the comprehensive manual for Cypher.
-* link:{neo4j-docs-base-uri}/driver-manual/4.0/[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
-* link:{neo4j-docs-base-uri}/operations-manual/4.0/[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
+* link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/[The Cypher manual] -- This is the comprehensive manual for Cypher.
+* link:{neo4j-docs-base-uri}/driver-manual/{neo4j-version}/[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
+* link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
 
 The https://neo4j.com/docs/cypher-refcard/current[Cypher Refcard] is a valuable asset when learning and writing Cypher.
 

--- a/modules/ROOT/pages/get-started-with-neo4j.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j.adoc
@@ -23,9 +23,9 @@ All the official documentation is available at link:https://neo4j.com/docs/[].
 
 That is where you find the full manuals such as:
 
-* xref:4.0@cypher-manual:ROOT:index.adoc#cypher-manual[The Cypher manual] -- This is the comprehensive manual for Cypher.
-* xref:4.0@driver-manual:ROOT:index.adoc#driver-manual[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
-* xref:4.0@operations-manual:ROOT:index.adoc#operations-manual[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
+* link:{neo4j-docs-base-uri}/cypher-manual/4.0/[The Cypher manual] -- This is the comprehensive manual for Cypher.
+* link:{neo4j-docs-base-uri}/driver-manual/4.0/[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
+* link:{neo4j-docs-base-uri}/operations-manual/4.0/[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
 
 The https://neo4j.com/docs/cypher-refcard/current[Cypher Refcard] is a valuable asset when learning and writing Cypher.
 

--- a/modules/ROOT/pages/graphdb-concepts.adoc
+++ b/modules/ROOT/pages/graphdb-concepts.adoc
@@ -240,7 +240,7 @@ CREATE (:Example {f: [1, 2, 3], g: [2.71, 3.14], h: ['abc', 'example'], i: [true
 
 [TIP]
 ====
-For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/4.0/syntax/values/#cypher-values[Cypher manual -> Values and types].
+For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/syntax/values/#cypher-values[Cypher manual -> Values and types].
 ====
 
 
@@ -296,7 +296,7 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/indexes-for-full-text-search/#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/administration/indexes-for-full-text-search/#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 
 [[graphdb-constraints]]
@@ -304,7 +304,7 @@ For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j
 
 Constraints are used to make sure that the data adheres to the rules of the domain.
 To see examples of how to work with constraints, see xref::/cypher-intro/schema.adoc#cypher-intro-constraints[Using constraints].
-For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/constraints/#administration-constraints[Cypher manual -> Constraints].
+For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/administration/constraints/#administration-constraints[Cypher manual -> Constraints].
 
 
 [[graphdb-naming-conventions]]
@@ -324,4 +324,4 @@ The following naming conventions are recommended:
 |===
 
 
-For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/4.0/syntax/naming/#cypher-naming[Cypher manual -> Naming rules and recommendations].
+For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/syntax/naming/#cypher-naming[Cypher manual -> Naming rules and recommendations].

--- a/modules/ROOT/pages/graphdb-concepts.adoc
+++ b/modules/ROOT/pages/graphdb-concepts.adoc
@@ -240,7 +240,7 @@ CREATE (:Example {f: [1, 2, 3], g: [2.71, 3.14], h: ['abc', 'example'], i: [true
 
 [TIP]
 ====
-For a thorough description of the available data types, refer to the xref:4.0@cypher-manual:ROOT:syntax/values/index.adoc#cypher-values[Cypher manual -> Values and types].
+For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/4.0/syntax/values/#cypher-values[Cypher manual -> Values and types].
 ====
 
 
@@ -296,7 +296,7 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see xref:4.0@cypher-manual:ROOT:administration/indexes-for-full-text-search/index.adoc#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/indexes-for-full-text-search/#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
 
 
 [[graphdb-constraints]]
@@ -304,7 +304,7 @@ For detailed descriptions of how to work with indexes in Cypher, see xref:4.0@cy
 
 Constraints are used to make sure that the data adheres to the rules of the domain.
 To see examples of how to work with constraints, see xref::/cypher-intro/schema.adoc#cypher-intro-constraints[Using constraints].
-For detailed descriptions of how to work with constraints in Cypher, see the xref:4.0@cypher-manual:ROOT:administration/constraints/index.adoc#administration-constraints[Cypher manual -> Constraints].
+For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/4.0/administration/constraints/#administration-constraints[Cypher manual -> Constraints].
 
 
 [[graphdb-naming-conventions]]
@@ -324,4 +324,4 @@ The following naming conventions are recommended:
 |===
 
 
-For the precise naming rules, refer to the xref:4.0@cypher-manual:ROOT:syntax/naming/index.adoc#cypher-naming[Cypher manual -> Naming rules and recommendations].
+For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/4.0/syntax/naming/#cypher-naming[Cypher manual -> Naming rules and recommendations].

--- a/preview.yml
+++ b/preview.yml
@@ -44,3 +44,5 @@ asciidoc:
     experimental: ''
     copyright: 2022
     common-license-page-uri: https://neo4j.com/docs/license/
+    neo4j-base-uri: https://neo4j.com # this attribute should be an empty string in publish.yml
+    neo4j-docs-base-uri: https://neo4j.com/docs # this attribute should be an empty string in publish.yml


### PR DESCRIPTION
Replaces `xref:` to other manuals with `link:` as for #115