### PR TITLE
Replace external xrefs with link macros

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -10,6 +10,6 @@ asciidoc:
     neo4j-version: 3.5
     neo4j-version-exact: 3.5.29
     neo4j-buildnumber: 3.5
-    offset: '{offset}'
-    count: '{count}'
+    offset: '\\{offset}'
+    count: '\\{count}'
     

--- a/modules/ROOT/pages/cypher-intro/index.adoc
+++ b/modules/ROOT/pages/cypher-intro/index.adoc
@@ -39,7 +39,7 @@ This chapter includes:
 * xref::/cypher-intro/load-csv.adoc[Import data]
 
 
-For a comprehensive guide to Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/3.5/#cypher-manual[Cypher manual].
+For a comprehensive guide to Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/#cypher-manual[Cypher manual].
 
 
 // include::patterns.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/cypher-intro/index.adoc
+++ b/modules/ROOT/pages/cypher-intro/index.adoc
@@ -39,7 +39,7 @@ This chapter includes:
 * xref::/cypher-intro/load-csv.adoc[Import data]
 
 
-For a comprehensive guide to Cypher, see the xref:3.5@cypher-manual:ROOT:index.adoc#cypher-manual[Cypher manual].
+For a comprehensive guide to Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/3.5/#cypher-manual[Cypher manual].
 
 
 // include::patterns.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -6,7 +6,7 @@ This tutorial will demonstrate how to import data from CSV files using `LOAD CSV
 
 [NOTE]
 ====
-For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/3.5/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
+For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
 ====
 
 With `LOAD CSV` we can conveniently import data into Neo4j and have access to Cypher to perform actions on the data as desired.
@@ -101,7 +101,7 @@ This will ensure that the query executes in a performant way.
 
 In this example, the CSV files are stored in the default import directory on the database server, and we can access them using a `file:///` URL.
 Other locations are configurable, and additionally, `LOAD CSV` supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`.
-For complete instructions, see link:{neo4j-docs-base-uri}/cypher-manual/3.5/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
+For complete instructions, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
 
 Using the following Cypher queries, we will create a node for each person, a node for each movie and a relationship between the two with a property denoting the role.
 We are also keeping track of the country in which each movie was made.
@@ -143,7 +143,7 @@ CREATE (person)-[:ACTED_IN {role: csvLine.role}]->(movie)
 [NOTE]
 For larger data files, it is useful to use the hint `USING PERIODIC COMMIT` clause of `LOAD CSV`.
 This hint tells Neo4j that the query might build up inordinate amounts of transaction state, and so needs to be periodically committed.
-For more information, see link:{neo4j-docs-base-uri}/cypher-manual/3.5/query-tuning/using/#query-using-periodic-commit-hint[].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/query-tuning/using/#query-using-periodic-commit-hint[].
 
 
 Finally, since the `id` property was only necessary to import the relationships, we can drop the constraints and the `id` property from all movie and person nodes.

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -6,7 +6,7 @@ This tutorial will demonstrate how to import data from CSV files using `LOAD CSV
 
 [NOTE]
 ====
-For a full description of `LOAD CSV` , see xref:3.5@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
+For a full description of `LOAD CSV` , see link:{neo4j-docs-base-uri}/cypher-manual/3.5/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
 ====
 
 With `LOAD CSV` we can conveniently import data into Neo4j and have access to Cypher to perform actions on the data as desired.
@@ -101,7 +101,7 @@ This will ensure that the query executes in a performant way.
 
 In this example, the CSV files are stored in the default import directory on the database server, and we can access them using a `file:///` URL.
 Other locations are configurable, and additionally, `LOAD CSV` supports accessing CSV files via `HTTPS`, `HTTP`, and `FTP`.
-For complete instructions, see xref:3.5@cypher-manual:ROOT:clauses/load-csv/index.adoc#query-load-csv[Cypher Manual -> `LOAD CSV`].
+For complete instructions, see link:{neo4j-docs-base-uri}/cypher-manual/3.5/clauses/load-csv/#query-load-csv[Cypher Manual -> `LOAD CSV`].
 
 Using the following Cypher queries, we will create a node for each person, a node for each movie and a relationship between the two with a property denoting the role.
 We are also keeping track of the country in which each movie was made.
@@ -143,7 +143,7 @@ CREATE (person)-[:ACTED_IN {role: csvLine.role}]->(movie)
 [NOTE]
 For larger data files, it is useful to use the hint `USING PERIODIC COMMIT` clause of `LOAD CSV`.
 This hint tells Neo4j that the query might build up inordinate amounts of transaction state, and so needs to be periodically committed.
-For more information, see xref:3.5@cypher-manual:ROOT:query-tuning/using/index.adoc#query-using-periodic-commit-hint[].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/3.5/query-tuning/using/#query-using-periodic-commit-hint[].
 
 
 Finally, since the `id` property was only necessary to import the relationships, we can drop the constraints and the `id` property from all movie and person nodes.

--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -130,12 +130,12 @@ YIELD description, tokenNames, properties, type;
 2 rows
 ----
 
-Learn more about indexes in xref:3.5@cypher-manual:ROOT:schema/index.adoc#query-schema-index[Cypher manual -> Indexes].
+Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/#query-schema-index[Cypher manual -> Indexes].
 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in xref:3.5@cypher-manual:ROOT:query-tuning/index.adoc#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/3.5/query-tuning/#query-tuning[Cypher manual -> Query tuning].
 ====
 
 
@@ -183,4 +183,4 @@ The constraint described above is available for all editions of Neo4j.
 Additional constraints are available for Neo4j Enterprise Edition.
 ====
 
-Learn more about constraints in xref:3.5@cypher-manual:ROOT:schema/constraints/index.adoc#query-constraints[Cypher manual -> Constraints].
+Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/constraints/#query-constraints[Cypher manual -> Constraints].

--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -130,12 +130,12 @@ YIELD description, tokenNames, properties, type;
 2 rows
 ----
 
-Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/#query-schema-index[Cypher manual -> Indexes].
+Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/schema/#query-schema-index[Cypher manual -> Indexes].
 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/3.5/query-tuning/#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/query-tuning/#query-tuning[Cypher manual -> Query tuning].
 ====
 
 
@@ -183,4 +183,4 @@ The constraint described above is available for all editions of Neo4j.
 Additional constraints are available for Neo4j Enterprise Edition.
 ====
 
-Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/constraints/#query-constraints[Cypher manual -> Constraints].
+Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/schema/constraints/#query-constraints[Cypher manual -> Constraints].

--- a/modules/ROOT/pages/get-started-with-neo4j.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j.adoc
@@ -18,9 +18,9 @@ Download Neo4j Desktop from https://neo4j.com/download/ and follow the installat
 All the official documentation is available at https://neo4j.com/docs/.
 That is where you find the full manuals such as:
 
-* xref:3.5@cypher-manual:ROOT:index.adoc#cypher-manual[The Cypher manual] -- This is the comprehensive manual for Cypher.
-* xref:1.7@driver-manual:ROOT:index.adoc#driver-manual[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
-* xref:3.5@operations-manual:ROOT:index.adoc#operations-manual[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
+* link:{neo4j-docs-base-uri}/cypher-manual/3.5[The Cypher manual] -- This is the comprehensive manual for Cypher.
+* link:{neo4j-docs-base-uri}/driver-manual/1.7/[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
+* link:{neo4j-docs-base-uri}/operations-manual/3.5/[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
 
 The https://neo4j.com/docs/cypher-refcard/current[Cypher Refcard] is a valuable asset when learning and writing Cypher.
 

--- a/modules/ROOT/pages/get-started-with-neo4j.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j.adoc
@@ -18,9 +18,9 @@ Download Neo4j Desktop from https://neo4j.com/download/ and follow the installat
 All the official documentation is available at https://neo4j.com/docs/.
 That is where you find the full manuals such as:
 
-* link:{neo4j-docs-base-uri}/cypher-manual/3.5[The Cypher manual] -- This is the comprehensive manual for Cypher.
+* link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}[The Cypher manual] -- This is the comprehensive manual for Cypher.
 * link:{neo4j-docs-base-uri}/driver-manual/1.7/[The Driver manual] -- This manual describes the officially supported drivers for Neo4j.
-* link:{neo4j-docs-base-uri}/operations-manual/3.5/[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
+* link:{neo4j-docs-base-uri}/operations-manual/{neo4j-version}/[The Operations manual] -- This manual describes how to deploy and maintain Neo4j.
 
 The https://neo4j.com/docs/cypher-refcard/current[Cypher Refcard] is a valuable asset when learning and writing Cypher.
 

--- a/modules/ROOT/pages/graphdb-concepts.adoc
+++ b/modules/ROOT/pages/graphdb-concepts.adoc
@@ -184,7 +184,7 @@ Properties are name-value pairs that are used to add qualities to nodes and rela
 In our example graphs, we have used the properties `name` and `born` on `Person` nodes, `title` and `released` on `Movie` nodes, and the property `roles` on the `:ACTED_IN` relationship.
 
 The value part of the property can hold different data types such as `number`, `string` and `boolean`.
-For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/3.5/syntax/values/#cypher-values[Cypher manual].
+For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/syntax/values/#cypher-values[Cypher manual].
 
 [[graphdb-traversal]]
 == Traversals and paths
@@ -282,14 +282,14 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-schema-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/#query-schema-index[Cypher manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/schema/#query-schema-index[Cypher manual -> Indexes].
 
 [[graphdb-schema-constraints]]
 === Constraints
 
 Constraints are used to make sure that the data adheres to the rules of the domain.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-schema-constraints[Using constraints].
-For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/constraints/#query-constraints[Cypher manual -> Constraints].
+For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/schema/constraints/#query-constraints[Cypher manual -> Constraints].
 
 
 [[graphdb-naming-rules-and-recommendations]]
@@ -308,4 +308,4 @@ It is recommended to follow the naming conventions described in the following ta
 |===
 
 
-For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/3.5/syntax/naming/#cypher-naming[Cypher manual -> Naming rules and recommendations].
+For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/{neo4j-version}/syntax/naming/#cypher-naming[Cypher manual -> Naming rules and recommendations].

--- a/modules/ROOT/pages/graphdb-concepts.adoc
+++ b/modules/ROOT/pages/graphdb-concepts.adoc
@@ -184,7 +184,7 @@ Properties are name-value pairs that are used to add qualities to nodes and rela
 In our example graphs, we have used the properties `name` and `born` on `Person` nodes, `title` and `released` on `Movie` nodes, and the property `roles` on the `:ACTED_IN` relationship.
 
 The value part of the property can hold different data types such as `number`, `string` and `boolean`.
-For a thorough description of the available data types, refer to the xref:3.5@cypher-manual:ROOT:syntax/values/index.adoc#cypher-values[Cypher manual].
+For a thorough description of the available data types, refer to the link:{neo4j-docs-base-uri}/cypher-manual/3.5/syntax/values/#cypher-values[Cypher manual].
 
 [[graphdb-traversal]]
 == Traversals and paths
@@ -282,14 +282,14 @@ Indexes and constraints can be introduced when desired, in order to gain perform
 
 Indexes are used to increase performance.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-schema-indexes[Using indexes].
-For detailed descriptions of how to work with indexes in Cypher, see xref:3.5@cypher-manual:ROOT:schema/index.adoc#query-schema-index[Cypher manual -> Indexes].
+For detailed descriptions of how to work with indexes in Cypher, see link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/#query-schema-index[Cypher manual -> Indexes].
 
 [[graphdb-schema-constraints]]
 === Constraints
 
 Constraints are used to make sure that the data adheres to the rules of the domain.
 To see examples of how to work with indexes, see xref::/cypher-intro/schema.adoc#cypher-intro-schema-constraints[Using constraints].
-For detailed descriptions of how to work with constraints in Cypher, see the xref:3.5@cypher-manual:ROOT:schema/constraints/index.adoc#query-constraints[Cypher manual -> Constraints].
+For detailed descriptions of how to work with constraints in Cypher, see the link:{neo4j-docs-base-uri}/cypher-manual/3.5/schema/constraints/#query-constraints[Cypher manual -> Constraints].
 
 
 [[graphdb-naming-rules-and-recommendations]]
@@ -308,4 +308,4 @@ It is recommended to follow the naming conventions described in the following ta
 |===
 
 
-For the precise naming rules, refer to the xref:3.5@cypher-manual:ROOT:syntax/naming/index.adoc#cypher-naming[Cypher manual -> Naming rules and recommendations].
+For the precise naming rules, refer to the link:{neo4j-docs-base-uri}/cypher-manual/3.5/syntax/naming/#cypher-naming[Cypher manual -> Naming rules and recommendations].

--- a/preview.yml
+++ b/preview.yml
@@ -44,3 +44,5 @@ asciidoc:
     experimental: ''
     copyright: 2021
     common-license-page-uri: https://neo4j.com/docs/license/
+    neo4j-base-uri: https://neo4j.com # this attribute should be an empty string in publish.yml
+    neo4j-docs-base-uri: https://neo4j.com/docs # this attribute should be an empty string in publish.yml


### PR DESCRIPTION
Replaces `xref:` to other manuals with `link:` as for #115