### PR TITLE
Fix uri attribute for linking to other manuals

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -52,4 +52,4 @@ asciidoc:
     copyright: 2021
     common-license-page-uri: https://neo4j.com/docs/license/
     neo4j-base-uri: '' # this attribute is empty for publish playbooks
-    neo4j-docs-base-uri: 'docs/'  # this attribute does not contain the full neo4j.com path for publish playbooks
+    neo4j-docs-base-uri: '/docs'  # this attribute does not contain the full neo4j.com path for publish playbooks


### PR DESCRIPTION
Updates the publish playbook with the correct path for links to pages in other manuals