### PR TITLE
Fix the cluster terminology for v5

### DIFF
--- a/modules/ROOT/pages/cypher-intro/results.adoc
+++ b/modules/ROOT/pages/cypher-intro/results.adoc
@@ -732,7 +732,7 @@ RETURN p.name, size(collect(friend.name)) AS numberOfFriends;
 .Query5 Results:
 image:cypher_agg_size.jpg[role="popup-link"]
 
-In Neo4j 5, if you need to find a number of relationship patterns, use the `COUNT {}` expression.
+In Neo4j v5, if you need to find a number of relationship patterns, use the `COUNT {}` expression.
 Take a look at the following example of the Cypher query.
 
 [source, cypher]

--- a/modules/ROOT/pages/cypher-intro/results.adoc
+++ b/modules/ROOT/pages/cypher-intro/results.adoc
@@ -732,7 +732,7 @@ RETURN p.name, size(collect(friend.name)) AS numberOfFriends;
 .Query5 Results:
 image:cypher_agg_size.jpg[role="popup-link"]
 
-In Neo4j 5.0, if you need to find a number of relationship patterns, you should use the `COUNT {}` expression.
+In Neo4j 5, if you need to find a number of relationship patterns, use the `COUNT {}` expression.
 Take a look at the following example of the Cypher query.
 
 [source, cypher]

--- a/modules/ROOT/pages/get-started-with-neo4j/index.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j/index.adoc
@@ -7,7 +7,7 @@ There are a number of options on how to get started with Neo4j, and your choice 
 [[neo4j-first-steps]]
 == First steps with Neo4j
 
-1. If you want to learn Neo4j graph database features, how to write Cypher queries, use developer tools like xref:get-started-with-neo4j/graph-platform.adoc#neo4j-tools[Neo4j Browser and Bloom], and get an overview on how to connect to Neo4j via drivers and connectors, go to the link:https://neo4j.com/cloud/platform/aura-graph-database/[AuraDB page], where you can create a new Neo4j instance free forever. +
+1. If your purpose is to learn Neo4j graph database features, how to write Cypher queries, use developer tools like xref:get-started-with-neo4j/graph-platform.adoc#neo4j-tools[Neo4j Browser and Bloom] and get an overview on how to connect to Neo4j via drivers and connectors, go to the link:https://neo4j.com/cloud/platform/aura-graph-database/[AuraDB page], where you can create a Neo4j instance free forever. +
 AuraDB is the best choice for cloud developers who are interested in graph technologies. +
 Besides the free option, you can select the subscription plan which suits you best. +
 At the moment, you can choose one of the example datasets on Aura to learn more about Neo4j and Cypher queries:
@@ -54,7 +54,7 @@ In the leftside navigation bar you see:
 
 * **Neo4j DBMS** -- Documentation for the Neo4j graph database, a core product:
 ** link:https://neo4j.com/docs/getting-started/current/[Getting Started Guide] -- you are here. The starting point to enter the Neo4j world.
-** link:https://neo4j.com/docs/operations-manual/current/[The Neo4j Operations Manual] -- the docset tells you how to deploy, configure, support, and maintain Neo4j. You find comprehensive descriptions of Neo4j Causal Clustering here. 
+** link:https://neo4j.com/docs/operations-manual/current/[The Neo4j Operations Manual] -- the docset tells you how to deploy, configure, support, and maintain Neo4j. You find comprehensive descriptions of Neo4j Clustering here. 
 ** link:https://neo4j.com/docs/upgrade-migration-guide/current/[Neo4j Upgrade and Migration Guide] -- the guide describes how to keep your Neo4j deployment up-to-date.
 ** link:https://neo4j.com/docs/status-codes/current/[Status Code] -- overview of Neo4j status codes classifications, version changes, and also a complete list of all status codes Neo4j may return, and what they mean.
 ** link:https://neo4j.com/docs/java-reference/current/[Java Reference] tells you about advanced Java-centric usage of Neo4j, how to embed Neo4j in your own software and write extensions.

--- a/modules/ROOT/pages/get-started-with-neo4j/index.adoc
+++ b/modules/ROOT/pages/get-started-with-neo4j/index.adoc
@@ -7,8 +7,8 @@ There are a number of options on how to get started with Neo4j, and your choice 
 [[neo4j-first-steps]]
 == First steps with Neo4j
 
-1. If your purpose is to learn Neo4j graph database features, how to write Cypher queries, use developer tools like xref:get-started-with-neo4j/graph-platform.adoc#neo4j-tools[Neo4j Browser and Bloom] and get an overview on how to connect to Neo4j via drivers and connectors, go to the link:https://neo4j.com/cloud/platform/aura-graph-database/[AuraDB page], where you can create a Neo4j instance free forever. +
-AuraDB is the best choice for cloud developers who are interested in graph technologies. +
+1. If your purpose is to learn Neo4j graph database features, how to write Cypher queries, use developer tools like xref:get-started-with-neo4j/graph-platform.adoc#neo4j-tools[Neo4j Browser and Bloom], and get an overview on how to connect to Neo4j via drivers and connectors, go to the link:https://neo4j.com/cloud/platform/aura-graph-database/[AuraDB page], where you can create a Neo4j instance at no cost. +
+AuraDB is a good choice for cloud developers who are interested in graph technologies. +
 Besides the free option, you can select the subscription plan which suits you best. +
 At the moment, you can choose one of the example datasets on Aura to learn more about Neo4j and Cypher queries:
 * Movies
@@ -54,7 +54,8 @@ In the leftside navigation bar you see:
 
 * **Neo4j DBMS** -- Documentation for the Neo4j graph database, a core product:
 ** link:https://neo4j.com/docs/getting-started/current/[Getting Started Guide] -- you are here. The starting point to enter the Neo4j world.
-** link:https://neo4j.com/docs/operations-manual/current/[The Neo4j Operations Manual] -- the docset tells you how to deploy, configure, support, and maintain Neo4j. You find comprehensive descriptions of Neo4j Clustering here. 
+** link:https://neo4j.com/docs/operations-manual/current/[The Neo4j Operations Manual] -- the documentation tells you how to deploy, configure, support, and maintain Neo4j. 
+You can also find comprehensive descriptions of Neo4j clustering here. 
 ** link:https://neo4j.com/docs/upgrade-migration-guide/current/[Neo4j Upgrade and Migration Guide] -- the guide describes how to keep your Neo4j deployment up-to-date.
 ** link:https://neo4j.com/docs/status-codes/current/[Status Code] -- overview of Neo4j status codes classifications, version changes, and also a complete list of all status codes Neo4j may return, and what they mean.
 ** link:https://neo4j.com/docs/java-reference/current/[Java Reference] tells you about advanced Java-centric usage of Neo4j, how to embed Neo4j in your own software and write extensions.

--- a/modules/ROOT/pages/integration-tools/integration.adoc
+++ b/modules/ROOT/pages/integration-tools/integration.adoc
@@ -9,7 +9,7 @@ We want to give an overview about what's available and link to the original sour
 Neo4j Connectors are integrations provided by Neo4j and are supported for existing Enterprise customers.
 
 * link:https://neo4j.com/docs/spark/current/[Neo4j Connector for Apache Spark]
-* link:https://neo4j.com/labs/kafka/4.0/[Neo4j Connector for Apache Kafka] (also known as Neo4j-Streams)
+* link:https://neo4j.com/docs/kafka/[Neo4j Connector for Apache Kafka] (also known as Neo4j Streams)
 * link:https://neo4j.com/bi-connector/[Neo4j Connector for Business Intelligence]
 
 

--- a/modules/ROOT/pages/languages-guides/index.adoc
+++ b/modules/ROOT/pages/languages-guides/index.adoc
@@ -32,7 +32,7 @@ This is straightforward to do using a driver which connects to Neo4j via Bolt or
 [#bolt-protocol]
 == The binary Bolt Protocol
 
-Starting with Neo4j v3.0, we support a binary protocol called Bolt.
+Starting with Neo4j v3.0, we support a binary protocol called link:https://neo4j.com/docs/bolt/current/[Bolt].
 It is based on the PackStream serialization and supports the Cypher type system, protocol versioning, authentication, and TLS via certificates.
 For Neo4j Clusters, Bolt provides smart client routing with load balancing and failover.
 

--- a/modules/ROOT/pages/languages-guides/index.adoc
+++ b/modules/ROOT/pages/languages-guides/index.adoc
@@ -24,15 +24,15 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 [#connect-neo4j]
 == How to connect to Neo4j?
 
-If you've created an link:{aura_signup}[AuraDB instance^], or link:/download/[installed] and started Neo4j as a server on your system,
-you can already work interactively with the database via the built-in Neo4j Browser, which you find in the AuraDB console, or if you're running locally, on http://localhost:7474[localhost:7474].
+If you've created an link:{aura_signup}[AuraDB instance^], or link:/download/[installed] and started Neo4j as a server on your system, you can already work interactively with the database via the built-in Neo4j Browser, which you find in the AuraDB console, or if you're running locally, on http://localhost:7474[localhost:7474].
 
-You are able to build an application, you want to connect to Neo4j from your technology stack, using a driver which connects to Neo4j via Bolt or HTTP.
+To build an application, you want to connect to Neo4j from your technology stack.
+This is straightforward to do using a driver which connects to Neo4j via Bolt or HTTP.
 
 [#bolt-protocol]
 == The binary Bolt Protocol
 
-Starting with Neo4j 3.0, we support a binary protocol called Bolt.
+Starting with Neo4j v3.0, we support a binary protocol called Bolt.
 It is based on the PackStream serialization and supports the Cypher type system, protocol versioning, authentication, and TLS via certificates.
 For Neo4j Clusters, Bolt provides smart client routing with load balancing and failover.
 

--- a/modules/ROOT/pages/languages-guides/index.adoc
+++ b/modules/ROOT/pages/languages-guides/index.adoc
@@ -53,7 +53,7 @@ _For more details on the protocol implementation, see the https://github.com/neo
 [#neo4j-drivers]
 == All Neo4j Drivers
 
-Thanks to the Neo4j contributor community, there are additionally drivers for almost every popular programming language,
+Thanks to the Neo4j contributor community, there are additional drivers for almost every popular programming language,
 most of which mimic existing database driver idioms and approaches.
 Get started with your stack now, see the dedicated page for more detail.
 

--- a/modules/ROOT/pages/languages-guides/index.adoc
+++ b/modules/ROOT/pages/languages-guides/index.adoc
@@ -27,14 +27,13 @@ You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or l
 If you've created an link:{aura_signup}[AuraDB instance^], or link:/download/[installed] and started Neo4j as a server on your system,
 you can already work interactively with the database via the built-in Neo4j Browser, which you find in the AuraDB console, or if you're running locally, on http://localhost:7474[localhost:7474].
 
-To build an application, you want to connect to Neo4j from your technology stack.
-Fortunately it is very easy using a driver which connects to Neo4j via Bolt or HTTP.
+You are able to build an application, you want to connect to Neo4j from your technology stack, using a driver which connects to Neo4j via Bolt or HTTP.
 
 [#bolt-protocol]
 == The binary Bolt Protocol
 
-Starting with Neo4j 3.0 we support a binary protocol called Bolt.
-It is based on the PackStream serialization and supports the Cypher type system, protocol versioning, authentication and TLS via certificates.
+Starting with Neo4j 3.0, we support a binary protocol called Bolt.
+It is based on the PackStream serialization and supports the Cypher type system, protocol versioning, authentication, and TLS via certificates.
 For Neo4j Clusters, Bolt provides smart client routing with load balancing and failover.
 
 The binary protocol is enabled in Neo4j by default, so you can use any language driver that supports it.
@@ -60,21 +59,21 @@ Get started with your stack now, see the dedicated page for more detail.
 
 [cols="5*",width=100]
 |===
-| link:/developer/java/[icon:check-circle-o[] Java]
-| link:/developer/spring-data-neo4j/[icon:check-circle-o[] Spring]
-| link:/developer/neo4j-ogm/[icon:check-circle-o[] Neo4j-OGM]
-| link:/developer/dotnet/[icon:check-circle-o[] .NET]
-| link:/developer/javascript/[icon:check-circle-o[] JavaScript]
-| link:/developer/python/[icon:check-circle-o[] Python]
-| link:/developer/go/[icon:check-circle-o[] Go]
-| link:/developer/ruby/[Ruby]
-| link:/developer/php/[PHP]
-| link:/developer/erlang-elixir/[Erlang/Elixir]
-| link:/developer/perl/[Perl]
-| link:/developer/c/[C/C++]
-| link:/developer/clojure/[Clojure]
-| link:/developer/haskell/[Haskell]
-| link:/developer/r/[R]
+| link:https://neo4j.com/developer/java/[icon:check-circle-o[] Java]
+| link:https://neo4j.com/developer/spring-data-neo4j/[icon:check-circle-o[] Spring]
+| link:https://neo4j.com/developer/neo4j-ogm/[icon:check-circle-o[] Neo4j-OGM]
+| link:https://neo4j.com/developer/dotnet/[icon:check-circle-o[] .NET]
+| link:https://neo4j.com/developer/javascript/[icon:check-circle-o[] JavaScript]
+| link:https://neo4j.com/developer/python/[icon:check-circle-o[] Python]
+| link:https://neo4j.com/developer/go/[icon:check-circle-o[] Go]
+| link:https://neo4j.com/developer/ruby/[Ruby]
+| link:https://neo4j.com/developer/php/[PHP]
+| link:https://neo4j.com/developer/erlang-elixir/[Erlang/Elixir]
+| link:https://neo4j.com/developer/perl/[Perl]
+| link:https://neo4j.com/developer/c/[C/C++]
+| link:https://neo4j.com/developer/clojure/[Clojure]
+| link:https://neo4j.com/developer/haskell/[Haskell]
+| link:https://neo4j.com/developer/r/[R]
 |===
 
 If you are new to development, we recommend the https://www.jetbrains.com/products.html[Jetbrains IDE^] for a good developer experience, which also comes with a link:/blog/jetbrains-ide-plugin-graph-database/[Neo4j Database plugin^].

--- a/modules/ROOT/pages/languages-guides/java/java-intro.adoc
+++ b/modules/ROOT/pages/languages-guides/java/java-intro.adoc
@@ -15,10 +15,10 @@ While this guide is not comprehensive, it introduces the different APIs and link
 [abstract]
 You should be familiar with xref:appendix/graphdb-concepts/index.adoc[graph database concepts] and the property graph model.
 You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or link:/download/[installed Neo4j locally].
-When developing with Neo4j, please use Java 8 or 11 and your favorite IDE.
+When developing with Neo4j, use Java 8 or 11 and your favorite IDE.
 
 
-[#neo4j-java]
+[[neo4j-java]]
 == Neo4j for Java developers
 
 // image::{neo4j-img-base-uri}java.jpg[float=right,width=200]
@@ -45,7 +45,7 @@ You can learn more about our small, consistent example project across many diffe
 You will find the implementations for all drivers as https://github.com/neo4j-examples?q=movies[individual GitHub repositories^], which you can clone and deploy directly.
 
 
-[#java-driver]
+[[java-driver]]
 == Neo4j Java Driver
 
 
@@ -89,7 +89,7 @@ You can https://neo4j.com/docs/migration-guide/current/upgrade-driver/#_configur
 // tag::table[]
 .Table Scheme Usage
 |===
-| Certificate Type | Neo4j Causal Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
+| Certificate Type | Neo4j Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
 
 | *Unencrypted*
 | `neo4j`

--- a/modules/ROOT/pages/languages-guides/java/java-intro.adoc
+++ b/modules/ROOT/pages/languages-guides/java/java-intro.adoc
@@ -15,7 +15,7 @@ While this guide is not comprehensive, it introduces the different APIs and link
 [abstract]
 You should be familiar with xref:appendix/graphdb-concepts/index.adoc[graph database concepts] and the property graph model.
 You should have link:{aura_signup}[created an Neo4j AuraDB cloud instance], or link:/download/[installed Neo4j locally].
-When developing with Neo4j, use Java 8 or 11 and your favorite IDE.
+When developing with Neo4j, use Java 8 or 11 and your preferred IDE.
 
 
 [[neo4j-java]]

--- a/modules/ROOT/pages/languages-guides/neo4j-dotnet.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-dotnet.adoc
@@ -62,7 +62,7 @@ You can https://neo4j.com/docs/migration-guide/current/upgrade-driver/#_configur
 // tag::table[]
 .Table Scheme Usage
 |===
-| Certificate Type | Neo4j Causal Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
+| Certificate Type | Neo4j Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
 
 | *Unencrypted*
 | `neo4j`

--- a/modules/ROOT/pages/languages-guides/neo4j-go.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-go.adoc
@@ -55,7 +55,7 @@ You can https://neo4j.com/docs/migration-guide/current/upgrade-driver/#_configur
 // tag::table[]
 .Table Scheme Usage
 |===
-| Certificate Type | Neo4j Causal Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
+| Certificate Type | Neo4j Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
 
 | *Unencrypted*
 | `neo4j`

--- a/modules/ROOT/pages/languages-guides/neo4j-javascript.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-javascript.adoc
@@ -94,7 +94,7 @@ You can https://neo4j.com/docs/migration-guide/current/upgrade-driver/#_configur
 // tag::table[]
 .Table Scheme Usage
 |===
-| Certificate Type | Neo4j Causal Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
+| Certificate Type | Neo4j Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
 
 | *Unencrypted*
 | `neo4j`

--- a/modules/ROOT/pages/languages-guides/neo4j-python.adoc
+++ b/modules/ROOT/pages/languages-guides/neo4j-python.adoc
@@ -65,7 +65,7 @@ You can https://neo4j.com/docs/migration-guide/current/upgrade-driver/#_configur
 // tag::table[]
 .Table Scheme Usage
 |===
-| Certificate Type | Neo4j Causal Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
+| Certificate Type | Neo4j Cluster | Neo4j Standalone Server  | Direct Connection to Cluster Member
 
 | *Unencrypted*
 | `neo4j`


### PR DESCRIPTION
Replace 'Causal Cluster' by 'Cluster'.
Change link to the Kafka Connector manual on the docs page.
Some small tweaks in different sections.