### PR TITLE
Remove the CTA for NODES

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -53,11 +53,3 @@ asciidoc:
     common-license-page-uri: https://neo4j.com/docs/license/
     neo4j-base-uri: '' # this attribute is empty for publish playbooks
     neo4j-docs-base-uri: '/docs'  # this attribute does not contain the full neo4j.com path for publish playbooks
-    # page-ad-image: https://dist.neo4j.com/wp-content/uploads/20220901150057/Artboard-12.png
-    page-ad-overline-link: https://neo4j.com/nodes-2022
-    page-ad-overline: 16-17 November 2022
-    page-ad-title: NODES 2022
-    page-ad-description: Join us for a free, two-day virtual conference of technical presentations by developers and data scientists, solving problems with graphs.
-    page-ad-link: https://neo4j.com/nodes-2022
-    page-ad-underline-role: button
-    page-ad-underline: Save your space


### PR DESCRIPTION
Removes the CTA to NODES 2022, added in #125