### PR TITLE
Remove versions except LTS and CS

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['3.5','4.0','4.1','4.2','4.3','4.4','dev']
+    branches: ['4.4','dev']
     edit_url: https://github.com/neo4j/docs-getting-started/tree/{refname}/{path}
     exclude:
     - '!**/_includes/*'


### PR DESCRIPTION
Following a long discussion on whether the GSG should be unversioned or not, it was decided to remove unsupported versions from the version checker. Only the long-term supported version and the currently supported version remain. In our case it's 4.4 and 5.x versions. 