### PR TITLE
fixing link to neotypes docs, now instead leading to main page (#235)

### DIFF
--- a/modules/ROOT/pages/languages-guides/community-drivers/java-third-party.adoc
+++ b/modules/ROOT/pages/languages-guides/community-drivers/java-third-party.adoc
@@ -61,7 +61,7 @@ Just grab the https://github.com/neo4j-contrib/neo4j-jdbc/releases/latest[JAR of
 | icon:github[] Source | https://github.com/neo4j-contrib/neo4j-jdbc
 | icon:book[] Docs | https://github.com/neo4j-contrib/neo4j-jdbc/blob/master/README.adoc
 | icon:play-circle[] Example | {examples}/movies-java-jdbc
-| icon:book[] Blog Post | http://neo4j.com/blog/couchbase-jdbc-integrations-neo4j-3-0/
+| icon:book[] Blog Post | https://neo4j.com/blog/couchbase-jdbc-integrations-neo4j-3-0/
 |===
 
 [#java-jcypher]
@@ -127,7 +127,7 @@ The project aims to provide seamless integration with most popular scala infrast
 |===
 | icon:user[] Author | https://twitter.com/dimafeng[Dmitry Fedosov^]
 | icon:github[] Source | https://github.com/neotypes/neotypes
-| icon:book[] Docs | https://neotypes.github.io/neotypes/docs.html
+| icon:book[] Docs | https://neotypes.github.io/neotypes/
 | icon:book[] Article | http://dimafeng.com/2018/12/27/neotypes-1/
 | icon:play-circle[] Example | https://github.com/neotypes/examples
 |===


### PR DESCRIPTION
Cherry-picked from https://github.com/neo4j/docs-getting-started/pull/235