### PR TITLE
Fix the broken links to the Cypher manual (#269)

### DIFF
--- a/modules/ROOT/pages/cypher-intro/schema.adoc
+++ b/modules/ROOT/pages/cypher-intro/schema.adoc
@@ -55,7 +55,7 @@ In most cases it is not necessary to specify indexes when querying for data, as 
 [NOTE]
 ====
 It is possible to specify which index to use in a particular query, using _index hints_.
-This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning#query-tuning[Cypher manual -> Query tuning].
+This is one of several options for query tuning, described in detail in link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning[Cypher manual -> Query tuning].
 ====
 
 For example, the following query will automatically use the `example_index_1`:
@@ -97,7 +97,7 @@ Rows: 2
 
 [TIP]
 ====
-Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search#administration-indexes-fulltext-search[Cypher Manual -> Indexes].
+Learn more about indexes in link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance#indexes-types-and-limitations[Cypher Manual -> Indexes].
 ====
 
 
@@ -171,5 +171,5 @@ Additional constraints are available for Neo4j Enterprise Edition.
 
 [TIP]
 ====
-Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints#administration-constraints[Cypher manual -> Constraints].
+Learn more about constraints in link:{neo4j-docs-base-uri}/cypher-manual/current/constraints[Cypher manual -> Constraints].
 ====


### PR DESCRIPTION
Add the registered trademark icon on the first usage of Cypher on every page of the manual