### PR TITLE
docs: fix typos

### DIFF
--- a/modules/ROOT/pages/appendix/graphdb-concepts/graphdb-vs-rdbms.adoc
+++ b/modules/ROOT/pages/appendix/graphdb-concepts/graphdb-vs-rdbms.adoc
@@ -41,7 +41,7 @@ Unlike other database management systems, relationships are of equal importance 
 This means we are not required to infer connections between entities using special properties such as foreign keys or out-of-band processing like map-reduce.
 
 By assembling nodes and relationships into connected structures, graph databases enable us to build simple and sophisticated models that map closely to our problem domain.
-The data stays remarkably similiar to its form in the real world - small, normalized, yet richly connected entities.
+The data stays remarkably similar to its form in the real world - small, normalized, yet richly connected entities.
 This allows you to query and view your data from any imaginable point of interest, supporting many different use cases.
 
 Each node (entity or attribute) in the graph database model directly and physically contains a list of relationship records that represent the relationships to other nodes.

--- a/modules/ROOT/pages/appendix/graphdb-concepts/index.adoc
+++ b/modules/ROOT/pages/appendix/graphdb-concepts/index.adoc
@@ -28,8 +28,8 @@ In mathematics, graph theory is the study of graphs.
 
 In graph theory:
 
-* Nodes are also refered to as vertices or points.
-* Relationships are also refered to as edges, links, or lines.
+* Nodes are also referred to as vertices or points.
+* Relationships are also referred to as edges, links, or lines.
 ====
 
 

--- a/modules/ROOT/pages/appendix/tutorials/guide-build-a-recommendation-engine.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-build-a-recommendation-engine.adoc
@@ -8,7 +8,7 @@
 
 [#cypher-tutorial]
 Graphs are everywhere.
-By following the meaningful relationships between the people and movies, you can determine occurences of actors working together, the frequency of actors working with one another, and the movies they have in common in the graph.
+By following the meaningful relationships between the people and movies, you can determine occurrences of actors working together, the frequency of actors working with one another, and the movies they have in common in the graph.
 This is one way we can recommend movies to users, based on what they liked before, and their favorite actors.
 We will step you through everything you need to get started with AuraDB and Cypher, to solve a real-world problem.
 

--- a/modules/ROOT/pages/cypher-intro/dates-datetimes-durations.adoc
+++ b/modules/ROOT/pages/cypher-intro/dates-datetimes-durations.adoc
@@ -269,7 +269,7 @@ RETURN article.title AS title,
 [#cypher-resources]
 == Resources
 
-This section has shown how to work more effectively with temporal types using the APOC libary.
+This section has shown how to work more effectively with temporal types using the APOC library.
 Below are some resources for learning more about using Temporal types in Neo4j:
 
 * link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/[Temporal (Date/Time) values in Cypher^]

--- a/modules/ROOT/pages/cypher-intro/load-csv.adoc
+++ b/modules/ROOT/pages/cypher-intro/load-csv.adoc
@@ -152,7 +152,7 @@ Or using link:{neo4j-docs-base-uri}/operations-manual/current/tools/cypher-shell
 bin/cypher-shell --database=neo4j "CREATE CONSTRAINT personIdConstraint FOR (person:Person) REQUIRE person.id IS UNIQUE"
 ----
 
-**+3.+ Create a constraint so that each `Movie` node has a unique `id` propery.**
+**+3.+ Create a constraint so that each `Movie` node has a unique `id` property.**
 
 You create a constraint on the `id` property of `Movie` nodes to ensure that nodes with the `Movie` label will have a unique `id` property.
 

--- a/modules/ROOT/pages/data-import/relational-to-graph-import.adoc
+++ b/modules/ROOT/pages/data-import/relational-to-graph-import.adoc
@@ -111,7 +111,7 @@ Processes that need to log information to Neo4j or flexibility for embedding in 
 All of this functionality is bundled out-of-the-box through a simple, yet powerful GUI for your ETL developers.
 Cooperation with Neo4j simply requires the plugins for our graph data integration.
 
-=== Kettle Resoures
+=== Kettle Resources
 * Kettle Download: https://sourceforge.net/projects/pentaho/files/[Open-source project on SourceForge^]
 * Neo4j Plugins: https://github.com/knowbi/knowbi-pentaho-pdi-neo4j-output/releases/[Integrate Kettle with Neo4j^]
 * Blog post: https://medium.com/neo4j/getting-started-with-kettle-and-neo4j-32ff15b991f9[Getting Started with Kettle and Neo4j^]

--- a/modules/ROOT/pages/data-modeling/modeling-designs.adoc
+++ b/modules/ROOT/pages/data-modeling/modeling-designs.adoc
@@ -109,7 +109,7 @@ One excellent example of a complex data structure that is difficult to model is 
 In the Marvel universe, there are comics that have characters who make appearances or play lead roles.
 Comics can be organized into a series of particular storylines or narratives for a certain time, and major events can take place in a comic that define a character path or series.
 Creators (including writers, illustrators, etc) are the authors of comics, defining storyline, character adaptations, and events that happen.
-Multiple creators can also participate interchangably to create a comic or series.
+Multiple creators can also participate interchangeably to create a comic or series.
 
 This dataset already seems complicated, with several entities and relationships at work.
 It adds a new layer of complexity when trying to model the hierarchies and intermediate entities that exist here.


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `modules/ROOT/pages/appendix/graphdb-concepts/graphdb-vs-rdbms.adoc`
2 typos in `modules/ROOT/pages/appendix/graphdb-concepts/index.adoc`
1 typo in `modules/ROOT/pages/appendix/tutorials/guide-build-a-recommendation-engine.adoc`
1 typo in `modules/ROOT/pages/cypher-intro/dates-datetimes-durations.adoc`
1 typo in `modules/ROOT/pages/cypher-intro/load-csv.adoc`
1 typo in `modules/ROOT/pages/data-import/relational-to-graph-import.adoc`
1 typo in `modules/ROOT/pages/data-modeling/modeling-designs.adoc`


Best!