### PR TITLE
Fix or/and typo in query with 'WITH'

### DIFF
--- a/modules/ROOT/pages/cypher-intro/results.adoc
+++ b/modules/ROOT/pages/cypher-intro/results.adoc
@@ -542,7 +542,7 @@ To trim out duplicate entities, you can use the `DISTINCT` keyword.
 
 [source, cypher]
 ----
-//Query: find people who have a twitter or like graphs or query languages
+//Query: find people who have a twitter and like graphs or query languages
 MATCH (user:Person)
 WHERE user.twitter IS NOT null
 WITH user


### PR DESCRIPTION
Usage of `and` should be replaced with `or` for this case, as per the description: "users who have a Twitter account and who like graphs or query languages"