### PR TITLE
Update index.adoc Cypher example

### DIFF
--- a/modules/ROOT/pages/appendix/graphdb-concepts/index.adoc
+++ b/modules/ROOT/pages/appendix/graphdb-concepts/index.adoc
@@ -45,7 +45,7 @@ To create the example graph, use the Cypher clause `CREATE`.
 
 [source, cypher]
 -----
-CREATE (:Person:Actor {name: 'Tom Hanks', born: 1956})-[:ACTED_IN {roles: ['Forrest']}]->(:Movie {title: 'Forrest Gump'})<-[:DIRECTED]-(:Person {name: 'Robert Zemeckis', born: 1951})
+CREATE (:Person:Actor {name: 'Tom Hanks', born: 1956})-[:ACTED_IN {roles: ['Forrest']}]->(:Movie {title: 'Forrest Gump', released: 1994})<-[:DIRECTED]-(:Person {name: 'Robert Zemeckis', born: 1951})
 -----
 
 //.Cypher.


### PR DESCRIPTION
Fix small omission of the "release" prop for the "Movie" on the Cypher example to match de graph viz.

Page: https://neo4j.com/docs/getting-started/appendix/graphdb-concepts/#graphdb-example-graph

refers to current graph svg uri:
https://neo4j.com/docs/getting-started/_images/graph_simple-arr.svg