### PR TITLE
Update Cypher syntax for showing indexes

### DIFF
--- a/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
@@ -376,7 +376,7 @@ After you execute this code, you can run the following Cypher command to view th
 SHOW INDEXES;
 ----
 
-Two `token-lookup` indexes (one for node labels and one for relationship types) are present by default when creating a Neo4j database.
+Two token lookup indexes (one for node labels and one for relationship types) are present by default when creating a Neo4j database.
 They exclusively solve node label and relationship type predicates and assist with the population of other indexes.
 Deleting them may have negative performance implications.
 You should see these indexes (and constraint) in the database:

--- a/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
@@ -381,18 +381,44 @@ They exclusively solve node label and relationship type predicates and assist wi
 Deleting them may have negative performance implications.
 You should see these indexes (and constraint) in the database:
 
-[format="csv", options="header"]
+////
+[options="header", cols="12"]
 |===
-id,name,state,populationPercent,type,entityType,labelsOrTypes,properties,indexprovider,owningConstraint, lastRead, readCount
-7,category_id,ONLINE,100.0,RANGE,NODE,[Category],[categoryID],range-1.0,null,null,0
-6,employee_id,ONLINE,100.0,RANGE,NODE,[Employee],[employeeID],range-1.0,null,null,0
-1,index_343aff4e,ONLINE,100.0,LOOKUP,NODE,null,null,token-lookup-1.0,null,2023-12-06T12:30:12.510000000Z,2286
-2,index_f7700477,ONLINE,100.0,LOOKUP,RELATIONSHIP,null,null,token-lookup-1.0,null,null,0
-8,order_id,ONLINE,100.0,RANGE,NODE,[Order],[orderID],range-1.0,order_id,2023-12-06T13:22:06.950000000Z,3815
-3,product_id,ONLINE,100.0,RANGE,NODE,[Product],[productID],range-1.0,null,null,0
-4,product_name,ONLINE,100.0,RANGE,NODE,[Product],[productName],range-1.0,null,null,0
-5,supplier_id,ONLINE,100.0,RANGE,NODE,[Supplier],[supplierID],range-1.0,null,null,0
+|id |name |state |populationPercent |type |entityType |labelsOrTypes |properties |indexprovider |owningConstraint |lastRead |readCount
+
+|7 |category_id |ONLINE |100.0 |RANGE |NODE |[Category] |[categoryID] |range-1.0 |null |null |0
+|6 |employee_id |ONLINE |100.0 |RANGE |NODE |[Employee] |[employeeID] |range-1.0 |null |null |0
+|1 |index_343aff4e |ONLINE |100.0 |LOOKUP |NODE |null |null |token-lookup-1.0 |null |2023-12-06T12:30:12.510000000Z |2286
+|2 |index_f7700477 |ONLINE |100.0 |LOOKUP |RELATIONSHIP |null |null |token-lookup-1.0 |null |null |0
+|8 |order_id |ONLINE |100.0 |RANGE |NODE |[Order] |[orderID] |range-1.0 |order_id |2023-12-06T13:22:06.950000000Z |3815
+|3 |product_id |ONLINE |100.0 |RANGE |NODE |[Product] |[productID] |range-1.0 |null |null |0
+|4 |product_name |ONLINE |100.0 |RANGE |NODE |[Product] |[productName] |range-1.0 |null |null |0
+|5 |supplier_id |ONLINE |100.0 |RANGE |NODE |[Supplier] |[supplierID] |range-1.0 |null |null |0
 |===
+////
+
+[source, results]
+----
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|id|name          |state |populationPercent|type  |entityType  |labelsOrTypes|properties   |indexprovider   |owningConstraint|lastRead                      |readCount|
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|7 |category_id   |ONLINE|100.0            |RANGE |NODE        |[Category]   |[categoryID] |range-1.0       |null            |null                          |0        |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|6 |employee_id   |ONLINE|100.0            |RANGE |NODE        |[Employee]   |[employeeID] |range-1.0       |null            |null                          |0        |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|1 |index_343aff4e|ONLINE|100.0            |LOOKUP|NODE        |null         |null         |token-lookup-1.0|null            |2023-12-06T12:30:12.510000000Z|2286     |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|2 |index_f7700477|ONLINE|100.0            |LOOKUP|RELATIONSHIP|null         |null         |token-lookup-1.0|null            |null                          |0        |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|8 |order_id      |ONLINE|100.0            |RANGE |NODE        |[Order]      |[orderID]    |range-1.0       |order_id        |2023-12-06T13:22:06.950000000Z|3815     |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|3 |product_id    |ONLINE|100.0            |RANGE |NODE        |[Product]    |[productID]  |range-1.0       |null            |null                          |0        |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|4 |product_name  |ONLINE|100.0            |RANGE |NODE        |[Product]    |[productName]|range-1.0       |null            |null                          |0        |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|5 |supplier_id   |ONLINE|100.0            |RANGE |NODE        |[Supplier]   |[supplierID] |range-1.0       |null            |null                          |0        |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+----
 
 For more information on indexes and their use in Neo4j, go to the https://neo4j.com/docs/cypher-manual/current/planning-and-tuning/query-tuning/indexes/[Cypher Manual -> The use of indexes].
 

--- a/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
@@ -369,26 +369,29 @@ CREATE CONSTRAINT order_id FOR (o:Order) REQUIRE o.orderID IS UNIQUE;
 CALL db.awaitIndexes();
 ----
 
-After you execute this code, you can execute this code to view the indexes (and constraint) in the database:
+After you execute this code, you can run the following Cypher command to view the indexes in the database:
 
 [source, cypher]
 ----
-CALL db.indexes();
+SHOW INDEXES;
 ----
 
 You should see these indexes (and constraint) in the database:
 
 [format="csv", options="header"]
 |===
-id,name,state,populationPercent,uniqueness,type,entityType,labelsOrTypes,properties,provider
-5,category_id,ONLINE,100.0,NONUNIQUE,BTREE,NODE,[Category],[categoryID],native-btree-1.0
-4,employee_id,ONLINE,100.0,NONUNIQUE,BTREE,NODE,[Employee],[employeeID],native-btree-1.0
-6,order_id,ONLINE,100.0,UNIQUE,BTREE,NODE,[Order],[orderID],native-btree-1.0
-1,product_id,ONLINE,100.0,NONUNIQUE,BTREE,NODE,[Product],[productID],native-btree-1.0
-2,product_name,ONLINE,100.0,NONUNIQUE,BTREE,NODE,[Product],[productName],native-btree-1.0
-3,supplier_id,ONLINE,100.0,NONUNIQUE,BTREE,NODE,[Supplier],[supplierID],native-btree-1.0
+id,name,state,populationPercent,type,entityType,labelsOrTypes,properties,indexprovider,owningConstraint
+7,category_id,ONLINE,100.0,RANGE,NODE,[Category],[categoryID],range-1.0,null
+6,employee_id,ONLINE,100.0,RANGE,NODE,[Employee],[employeeID],range-1.0,null
+1,index_343aff4e,ONLINE,100.0,LOOKUP,NODE,null,null,token-lookup-1.0,null
+2,index_f7700477,ONLINE,100.0,LOOKUP,RELATIONSHIP,null,null,token-lookup-1.0,null
+8,order_id,ONLINE,100.0,RANGE,NODE,[Order],[orderID],range-1.0,order_id
+3,product_id,ONLINE,100.0,RANGE,NODE,[Product],[productID],range-1.0,null
+4,product_name,ONLINE,100.0,RANGE,NODE,[Product],[productName],range-1.0,null
+5,supplier_id,ONLINE,100.0,RANGE,NODE,[Supplier],[supplierID],range-1.0,null
 |===
 
+For more information on indexes and their use in Neo4j, go to the https://neo4j.com/docs/cypher-manual/current/planning-and-tuning/query-tuning/indexes/[Cypher Manual -> The use of indexes].
 
 == Creating the relationships between the nodes
 

--- a/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
@@ -376,6 +376,9 @@ After you execute this code, you can run the following Cypher command to view th
 SHOW INDEXES;
 ----
 
+Two `token-lookup` indexes (one for node labels and one for relationship types) are present by default when creating a Neo4j database.
+They exclusively solve node label and relationship type predicates and assist with the population of other indexes.
+Deleting them may have negative performance implications.
 You should see these indexes (and constraint) in the database:
 
 [format="csv", options="header"]

--- a/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
+++ b/modules/ROOT/pages/appendix/tutorials/guide-import-relational-and-etl.adoc
@@ -383,15 +383,15 @@ You should see these indexes (and constraint) in the database:
 
 [format="csv", options="header"]
 |===
-id,name,state,populationPercent,type,entityType,labelsOrTypes,properties,indexprovider,owningConstraint
-7,category_id,ONLINE,100.0,RANGE,NODE,[Category],[categoryID],range-1.0,null
-6,employee_id,ONLINE,100.0,RANGE,NODE,[Employee],[employeeID],range-1.0,null
-1,index_343aff4e,ONLINE,100.0,LOOKUP,NODE,null,null,token-lookup-1.0,null
-2,index_f7700477,ONLINE,100.0,LOOKUP,RELATIONSHIP,null,null,token-lookup-1.0,null
-8,order_id,ONLINE,100.0,RANGE,NODE,[Order],[orderID],range-1.0,order_id
-3,product_id,ONLINE,100.0,RANGE,NODE,[Product],[productID],range-1.0,null
-4,product_name,ONLINE,100.0,RANGE,NODE,[Product],[productName],range-1.0,null
-5,supplier_id,ONLINE,100.0,RANGE,NODE,[Supplier],[supplierID],range-1.0,null
+id,name,state,populationPercent,type,entityType,labelsOrTypes,properties,indexprovider,owningConstraint, lastRead, readCount
+7,category_id,ONLINE,100.0,RANGE,NODE,[Category],[categoryID],range-1.0,null,null,0
+6,employee_id,ONLINE,100.0,RANGE,NODE,[Employee],[employeeID],range-1.0,null,null,0
+1,index_343aff4e,ONLINE,100.0,LOOKUP,NODE,null,null,token-lookup-1.0,null,2023-12-06T12:30:12.510000000Z,2286
+2,index_f7700477,ONLINE,100.0,LOOKUP,RELATIONSHIP,null,null,token-lookup-1.0,null,null,0
+8,order_id,ONLINE,100.0,RANGE,NODE,[Order],[orderID],range-1.0,order_id,2023-12-06T13:22:06.950000000Z,3815
+3,product_id,ONLINE,100.0,RANGE,NODE,[Product],[productID],range-1.0,null,null,0
+4,product_name,ONLINE,100.0,RANGE,NODE,[Product],[productName],range-1.0,null,null,0
+5,supplier_id,ONLINE,100.0,RANGE,NODE,[Supplier],[supplierID],range-1.0,null,null,0
 |===
 
 For more information on indexes and their use in Neo4j, go to the https://neo4j.com/docs/cypher-manual/current/planning-and-tuning/query-tuning/indexes/[Cypher Manual -> The use of indexes].


### PR DESCRIPTION
As `BTREE` indexes were removed and replaced by indexes of other types, we have to update code blocks and results in the corresponding section of the tutorial _Import data from a relational database into Neo4j_.