### PR TITLE
Update example datasets page

### DIFF
--- a/modules/ROOT/pages/appendix/example-data.adoc
+++ b/modules/ROOT/pages/appendix/example-data.adoc
@@ -49,26 +49,6 @@ Other example datasets that you can run within your own Neo4j Browser are:
 // :play twitter-neo4j-stream
 // `:play life-science-import` drug and genome data import and repurposing examples
 
-== AuraDB Free example datasets
-
-When creating a new database in Neo4j AuraDB, besides the default empty you can also select one of the starting datasets:
-
-* Movies
-* Graph based Recommendations
-* Graphs for Cybersecurity
-* StackOverflow Data
-
-You can explore them following the Browser guides instructions and test data with suggested Cypher queries.
-
-In addition, you have few options to download graph data into Aura from other Neo4j instances:
-
-* Load a dump from Neo4j Sandbox backup.
-* Load a dump from Neo4j Graph Example repository.
-* Load a dump from Neo4j Desktop.
-
-For more information, you can read the blog post link:https://medium.com/neo4j/week-10-getting-dumps-and-example-projects-into-aura-free-6980b178dc69/[Week 10 -- Getting Dumps and Example Projects into Aura Free] and watch the corresponding link:https://www.youtube.com/watch?v=q6sU38nQiic&t=779s/[video] from the series *_Discover Neo4j Aura Free with Michael and Alex_*. 
-
-
 [#neo4j-sandbox]
 == Neo4j Sandbox
 

--- a/modules/ROOT/pages/appendix/example-data.adoc
+++ b/modules/ROOT/pages/appendix/example-data.adoc
@@ -49,6 +49,10 @@ Other example datasets that you can run within your own Neo4j Browser are:
 // :play twitter-neo4j-stream
 // `:play life-science-import` drug and genome data import and repurposing examples
 
+== Neo4j guides on Aura
+
+With a new instance on Aura, you can explore a set of Neo4j Guides created to adapt to your needs and learning style.
+Click on a student-hat button at the top, to access the Neo4j guides. 
 [#neo4j-sandbox]
 == Neo4j Sandbox
 


### PR DESCRIPTION
We definitely have to remove section on the Aura example datasets as they were replaced by the Workspace guides.
Probably we can add information about them. 