### PR TITLE
adding health warning about insecure protocols for LOAD CSV 

### DIFF
--- a/modules/ROOT/pages/data-import/csv-import.adoc
+++ b/modules/ROOT/pages/data-import/csv-import.adoc
@@ -99,6 +99,11 @@ There are a few things to keep in mind with `LOAD CSV` and a few helpful tips fo
 Labels, property names, relationship types, and variables are *case-sensitive*.
 * The cleaner the data, the easier the load. 
 Try to handle complex cleanup/manipulation before load.
+* It is strongly recommended to permit resource loading only over secure protocols such as HTTPS instead of insecure protocols like HTTP.
+This can be done by limiting the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/load-privileges/#access-control-load-cidr/[load privileges] to only trusted sources that use secure protocols.
+If allowing an insecure protocol is absolutely unavoidable, Neo4j takes measures internally to enhance the security of these requests within their limitations.
+However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/configuration-settings/#config_server.jvm.additional/[jvm.additional].
+
 
 === Converting data values with *LOAD CSV*
 

--- a/modules/ROOT/pages/data-import/csv-import.adoc
+++ b/modules/ROOT/pages/data-import/csv-import.adoc
@@ -102,7 +102,7 @@ Try to handle complex cleanup/manipulation before load.
 * It is strongly recommended to permit resource loading only over secure protocols such as HTTPS instead of insecure protocols like HTTP.
 This can be done by limiting the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/load-privileges/#access-control-load-cidr/[load privileges] to only trusted sources that use secure protocols.
 If allowing an insecure protocol is absolutely unavoidable, Neo4j takes measures internally to enhance the security of these requests within their limitations.
-However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/configuration-settings/#config_server.jvm.additional/[jvm.additional].
+However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/configuration-settings/#config_server.jvm.additional/[`server.jvm.additional`].
 
 
 === Converting data values with *LOAD CSV*


### PR DESCRIPTION
adds a warning against allowing insecure protocols for `LOAD CSV`

this PR is the getting-started manual copy of the [cypher manual equivalent](https://github.com/neo4j/docs-cypher/pull/1006)